### PR TITLE
feat: 판매자 로그인 기능 추가 [#32]

### DIFF
--- a/src/main/java/shop/sendbox/sendbox/api/ApiControllerAdvice.java
+++ b/src/main/java/shop/sendbox/sendbox/api/ApiControllerAdvice.java
@@ -10,6 +10,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import shop.sendbox.sendbox.security.auth.exception.AuthenticationException;
+import shop.sendbox.sendbox.security.auth.exception.AuthorizationException;
+
 /*
 기본적으로 서버에서 발생한 예외는 모두 500 에러로 처리됩니다.
 하지만 클라이언트가 잘못된 요청을 보낸 경우 400 에러로 처리를 해야합니다.
@@ -29,20 +32,27 @@ public class ApiControllerAdvice {
 	public ApiResponse<Object> handleIllegalAccessException(IllegalArgumentException error) {
 		return ApiResponse.of(HttpStatus.BAD_REQUEST, error.getMessage(), null);
 	}
-	
-	/**
-	 * Bean Validation 예외 처리
-	 * 유효성 검증에 실패한 필드와 메시지를 응답으로 반환합니다.
-	 */
+
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ApiResponse<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException exception) {
 		Map<String, String> errors = new HashMap<>();
 		exception.getBindingResult().getAllErrors().forEach(error -> {
-			String fieldName = ((FieldError) error).getField();
+			String fieldName = ((FieldError)error).getField();
 			String errorMessage = error.getDefaultMessage();
 			errors.put(fieldName, errorMessage);
 		});
 		return ApiResponse.of(HttpStatus.BAD_REQUEST, "입력값 검증에 실패했습니다", errors);
 	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	public ErrorResponse handleAuthenticationException() {
+		return ErrorResponse.unauthorized();
+	}
+
+	@ExceptionHandler(AuthorizationException.class)
+	public ErrorResponse handleAuthorizationException() {
+		return ErrorResponse.accessDenied();
+	}
+
 }

--- a/src/main/java/shop/sendbox/sendbox/api/ApiControllerAdvice.java
+++ b/src/main/java/shop/sendbox/sendbox/api/ApiControllerAdvice.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import shop.sendbox.sendbox.security.auth.exception.AuthenticationException;
 import shop.sendbox.sendbox.security.auth.exception.AuthorizationException;
+import shop.sendbox.sendbox.security.auth.exception.UserPrincipalNotSetException;
+import shop.sendbox.sendbox.security.auth.exception.UserPrincipalRequiredException;
 
 /*
 기본적으로 서버에서 발생한 예외는 모두 500 에러로 처리됩니다.
@@ -55,4 +57,15 @@ public class ApiControllerAdvice {
 		return ErrorResponse.accessDenied();
 	}
 
+	@ExceptionHandler(UserPrincipalNotSetException.class)
+	public ErrorResponse handleUserPrincipalNotSetException() {
+		return ErrorResponse.missingPrincipal();
+	}
+
+	@ExceptionHandler(UserPrincipalRequiredException.class)
+	public ErrorResponse handleUserPrincipalRequiredException() {
+		return ErrorResponse.unauthorized();
+	}
+
 }
+

--- a/src/main/java/shop/sendbox/sendbox/api/ErrorCode.java
+++ b/src/main/java/shop/sendbox/sendbox/api/ErrorCode.java
@@ -1,0 +1,40 @@
+package shop.sendbox.sendbox.api;
+
+public enum ErrorCode {
+
+	UNAUTHORIZED(401, "AUTH_001", "UNAUTHORIZED", "이 리소스에 접근하기 위해서는 인증이 필요합니다."),
+	MISSING_PRINCIPAL(401, "AUTH_002", "UNAUTHORIZED", "사용자 정보가 없습니다."),
+	ACCESS_DENIED(403, "AUTH_003", "ACCESS_DENIED", "이 리소스에 접근할 권한이 없습니다."),
+
+	SERVER_ERROR(500, "SYS_001", "SERVER_ERROR", "예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."),
+	BAD_REQUEST(400, "SYS_002", "BAD_REQUEST", "잘못된 요청입니다."),
+	INVALID_INPUT_VALUE(400, "SYS_003", "BAD_REQUEST", "입력값이 올바르지 않습니다.");
+
+	private final int statusCode;
+	private final String errorCode;
+	private final String message;
+	private final String defaultDetail;
+
+	ErrorCode(int statusCode, String errorCode, String message, String defaultDetail) {
+		this.statusCode = statusCode;
+		this.errorCode = errorCode;
+		this.message = message;
+		this.defaultDetail = defaultDetail;
+	}
+
+	public int getStatusCode() {
+		return statusCode;
+	}
+
+	public String getErrorCode() {
+		return errorCode;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public String getDefaultDetail() {
+		return defaultDetail;
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/api/ErrorResponse.java
+++ b/src/main/java/shop/sendbox/sendbox/api/ErrorResponse.java
@@ -1,51 +1,54 @@
 package shop.sendbox.sendbox.api;
 
-/**
- * 예외 발생 시 클라이언트에게 반환할 표준 에러 응답 형식
- */
 public record ErrorResponse(
 	int statusCode,
 	String message,
 	String errorCode,
 	String errorDetail
 ) {
-	public static ErrorResponse unauthorized() {
+	public static ErrorResponse of(ErrorCode errorCode) {
 		return new ErrorResponse(
-			401,
-			"UNAUTHORIZED",
-			"AUTH_001",
-			"이 리소스에 접근하기 위해서는 인증이 필요합니다."
+			errorCode.getStatusCode(),
+			errorCode.getMessage(),
+			errorCode.getErrorCode(),
+			errorCode.getDefaultDetail()
 		);
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode, String detail) {
+		return new ErrorResponse(
+			errorCode.getStatusCode(),
+			errorCode.getMessage(),
+			errorCode.getErrorCode(),
+			detail
+		);
+	}
+
+	public static ErrorResponse of(int status, String msg, String code, String detail) {
+		return new ErrorResponse(status, msg, code, detail);
+	}
+
+	public static ErrorResponse unauthorized() {
+		return of(ErrorCode.UNAUTHORIZED);
+	}
+
+	public static ErrorResponse missingPrincipal() {
+		return of(ErrorCode.MISSING_PRINCIPAL);
 	}
 
 	public static ErrorResponse accessDenied() {
-		return new ErrorResponse(
-			403,
-			"ACCESS_DENIED",
-			"AUTH_003",
-			"이 리소스에 접근할 권한이 없습니다."
-		);
+		return of(ErrorCode.ACCESS_DENIED);
 	}
 
 	public static ErrorResponse serverError() {
-		return new ErrorResponse(
-			500,
-			"SERVER_ERROR",
-			"SYS_001",
-			"예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
-		);
+		return of(ErrorCode.SERVER_ERROR);
 	}
 
-	public static ErrorResponse badRequest(String message) {
-		return new ErrorResponse(
-			400,
-			"BAD_REQUEST",
-			"SYS_002",
-			message
-		);
+	public static ErrorResponse badRequest() {
+		return of(ErrorCode.BAD_REQUEST);
 	}
 
-	public static ErrorResponse of(int statusCode, String message, String errorCode, String errorDetail) {
-		return new ErrorResponse(statusCode, message, errorCode, errorDetail);
+	public static ErrorResponse badRequest(String detail) {
+		return of(ErrorCode.BAD_REQUEST, detail);
 	}
 }

--- a/src/main/java/shop/sendbox/sendbox/api/ErrorResponse.java
+++ b/src/main/java/shop/sendbox/sendbox/api/ErrorResponse.java
@@ -1,0 +1,51 @@
+package shop.sendbox.sendbox.api;
+
+/**
+ * 예외 발생 시 클라이언트에게 반환할 표준 에러 응답 형식
+ */
+public record ErrorResponse(
+	int statusCode,
+	String message,
+	String errorCode,
+	String errorDetail
+) {
+	public static ErrorResponse unauthorized() {
+		return new ErrorResponse(
+			401,
+			"UNAUTHORIZED",
+			"AUTH_001",
+			"이 리소스에 접근하기 위해서는 인증이 필요합니다."
+		);
+	}
+
+	public static ErrorResponse accessDenied() {
+		return new ErrorResponse(
+			403,
+			"ACCESS_DENIED",
+			"AUTH_003",
+			"이 리소스에 접근할 권한이 없습니다."
+		);
+	}
+
+	public static ErrorResponse serverError() {
+		return new ErrorResponse(
+			500,
+			"SERVER_ERROR",
+			"SYS_001",
+			"예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+		);
+	}
+
+	public static ErrorResponse badRequest(String message) {
+		return new ErrorResponse(
+			400,
+			"BAD_REQUEST",
+			"SYS_002",
+			message
+		);
+	}
+
+	public static ErrorResponse of(int statusCode, String message, String errorCode, String errorDetail) {
+		return new ErrorResponse(statusCode, message, errorCode, errorDetail);
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/buyer/service/BuyerService.java
+++ b/src/main/java/shop/sendbox/sendbox/buyer/service/BuyerService.java
@@ -12,8 +12,8 @@ import shop.sendbox.sendbox.login.LoginHandler;
 import shop.sendbox.sendbox.login.LoginResponse;
 import shop.sendbox.sendbox.login.LoginUser;
 import shop.sendbox.sendbox.login.UserType;
-import shop.sendbox.sendbox.security.dto.PasswordData;
-import shop.sendbox.sendbox.security.service.SecurityService;
+import shop.sendbox.sendbox.security.crypto.dto.PasswordData;
+import shop.sendbox.sendbox.security.crypto.service.SecurityService;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/shop/sendbox/sendbox/config/WebMvcConfig.java
+++ b/src/main/java/shop/sendbox/sendbox/config/WebMvcConfig.java
@@ -1,0 +1,56 @@
+package shop.sendbox.sendbox.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import shop.sendbox.sendbox.security.auth.context.SecurityPrincipalHolder;
+import shop.sendbox.sendbox.security.auth.filter.ExceptionTranslationFilter;
+import shop.sendbox.sendbox.security.auth.filter.SessionAuthenticationFilter;
+import shop.sendbox.sendbox.security.auth.interceptor.AuthorizationInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final ObjectMapper objectMapper;
+	private final SecurityPrincipalHolder securityPrincipalHolder;
+
+	public WebMvcConfig(ObjectMapper objectMapper, SecurityPrincipalHolder securityPrincipalHolder) {
+		this.objectMapper = objectMapper;
+		this.securityPrincipalHolder = securityPrincipalHolder;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(authorizationInterceptor())
+			.addPathPatterns("/**");
+	}
+
+	@Bean
+	public AuthorizationInterceptor authorizationInterceptor() {
+		return new AuthorizationInterceptor(securityPrincipalHolder);
+	}
+
+	@Bean
+	public FilterRegistrationBean<ExceptionTranslationFilter> exceptionTranslationFilter() {
+		FilterRegistrationBean<ExceptionTranslationFilter> registrationBean = new FilterRegistrationBean<>();
+		registrationBean.setFilter(new ExceptionTranslationFilter(objectMapper));
+		registrationBean.addUrlPatterns("/*");
+		registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE); // 가장 먼저 실행
+		return registrationBean;
+	}
+
+	@Bean
+	public FilterRegistrationBean<SessionAuthenticationFilter> authenticationFilter() {
+		FilterRegistrationBean<SessionAuthenticationFilter> registrationBean = new FilterRegistrationBean<>();
+		registrationBean.setFilter(new SessionAuthenticationFilter(securityPrincipalHolder));
+		registrationBean.addUrlPatterns("/*");
+		registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE + 1); // 예외 필터 다음으로 실행
+		return registrationBean;
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/login/LoginCreateRequest.java
+++ b/src/main/java/shop/sendbox/sendbox/login/LoginCreateRequest.java
@@ -5,17 +5,17 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record LoginCreateRequest(
-    @NotBlank(message = "이메일은 필수 입력값입니다")
-    @Email(message = "이메일 형식이 올바르지 않습니다")
-    String email,
-    
-    @NotBlank(message = "비밀번호는 필수 입력값입니다")
-    String password,
-    
-    @NotNull(message = "사용자 유형은 필수 입력값입니다") 
-    UserType userType) {
-    
-    public LoginRequest toServiceRequest() {
-        return new LoginRequest(email, password, userType);
-    }
+	@NotBlank(message = "이메일은 필수 입력값입니다")
+	@Email(message = "이메일 형식이 올바르지 않습니다")
+	String email,
+
+	@NotBlank(message = "비밀번호는 필수 입력값입니다")
+	String password,
+
+	@NotNull(message = "사용자 유형은 필수 입력값입니다")
+	UserType userType) {
+
+	public LoginRequest toServiceRequest() {
+		return new LoginRequest(email, password, userType);
+	}
 }

--- a/src/main/java/shop/sendbox/sendbox/login/LoginResponse.java
+++ b/src/main/java/shop/sendbox/sendbox/login/LoginResponse.java
@@ -16,8 +16,4 @@ public record LoginResponse(
 		return new LoginResponse(seller.getId(), seller.getName(), email);
 	}
 
-	// 더 일반적인 팩토리 메서드 추가
-	public static LoginResponse from(Long id, String name, String email) {
-		return new LoginResponse(id, name, email);
-	}
 }

--- a/src/main/java/shop/sendbox/sendbox/login/UserType.java
+++ b/src/main/java/shop/sendbox/sendbox/login/UserType.java
@@ -1,5 +1,5 @@
 package shop.sendbox.sendbox.login;
 
 public enum UserType {
-	BUYER, SELLER
+	BUYER, SELLER, ADMIN;
 }

--- a/src/main/java/shop/sendbox/sendbox/security/auth/ApiEndpointEnum.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/ApiEndpointEnum.java
@@ -1,0 +1,46 @@
+package shop.sendbox.sendbox.security.auth;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.Assert;
+
+public enum ApiEndpointEnum {
+	COUPON_CREATE("/coupons", HttpMethod.POST, Permission.SELLER);
+
+	private final String path;
+	private final HttpMethod method;
+	private final Permission requiredPermission;
+	private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+	ApiEndpointEnum(String path, HttpMethod method, Permission requiredPermission) {
+		Assert.hasText(path, "Path는 필수 값입니다.");
+		Assert.notNull(method, "HttpMethod는 필수 값입니다.");
+		Assert.notNull(requiredPermission, "Permission은 필수 값입니다.");
+		this.path = path;
+		this.method = method;
+		this.requiredPermission = requiredPermission;
+	}
+
+	public boolean matches(String requestUri, String requestMethod) {
+		String pathWithoutQuery = removeUriQueryString(requestUri);
+		return isSameMethod(requestMethod) && PATH_MATCHER.match(path, pathWithoutQuery);
+	}
+
+	private String removeUriQueryString(String requestUri) {
+		return requestUri.contains("?") ? requestUri.substring(0, requestUri.indexOf("?")) : requestUri;
+	}
+
+	private boolean isSameMethod(String requestMethod) {
+		return method.name().equalsIgnoreCase(requestMethod);
+	}
+
+	public static Permission matchEndpoint(String requestUri, String requestMethod) {
+		for (ApiEndpointEnum endpoint : values()) {
+			if (endpoint.matches(requestUri, requestMethod)) {
+				return endpoint.requiredPermission;
+			}
+		}
+		return Permission.PUBLIC;
+	}
+
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/Permission.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/Permission.java
@@ -1,0 +1,22 @@
+package shop.sendbox.sendbox.security.auth;
+
+public enum Permission {
+	PUBLIC("public"),
+	BUYER("buyer"),
+	SELLER("seller"),
+	ADMIN("admin");
+
+	private final String value;
+
+	Permission(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public boolean doesNotRequireAuth() {
+		return this == PUBLIC;
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/UserPrincipal.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/UserPrincipal.java
@@ -11,25 +11,25 @@ public class UserPrincipal {
 
 	private final String id;
 	private final UserType userType;
-	private final Set<Permission> permissions;
+	private final Set<Permission> allowsPermission;
 
 	public UserPrincipal(String id, UserType userType) {
 		this.id = id;
 		this.userType = userType;
-		this.permissions = EnumSet.noneOf(Permission.class);
+		this.allowsPermission = EnumSet.noneOf(Permission.class);
 		initPermissions();
 	}
 
 	private void initPermissions() {
 		switch (userType) {
 			case BUYER:
-				permissions.add(Permission.BUYER);
+				allowsPermission.add(Permission.BUYER);
 				break;
 			case SELLER:
-				permissions.add(Permission.SELLER);
+				allowsPermission.add(Permission.SELLER);
 				break;
 			case ADMIN:
-				permissions.addAll(EnumSet.allOf(Permission.class));
+				allowsPermission.addAll(EnumSet.allOf(Permission.class));
 				break;
 		}
 	}
@@ -41,7 +41,7 @@ public class UserPrincipal {
 	public boolean hasPermission(Permission currentPermission) {
 		Assert.notNull(currentPermission, "currentPermission은 필수입니다.");
 
-		if (permissions.contains(currentPermission)) {
+		if (allowsPermission.contains(currentPermission)) {
 			return true;
 		}
 

--- a/src/main/java/shop/sendbox/sendbox/security/auth/UserPrincipal.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/UserPrincipal.java
@@ -1,0 +1,50 @@
+package shop.sendbox.sendbox.security.auth;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.springframework.util.Assert;
+
+import shop.sendbox.sendbox.login.UserType;
+
+public class UserPrincipal {
+
+	private final String id;
+	private final UserType userType;
+	private final Set<Permission> permissions;
+
+	public UserPrincipal(String id, UserType userType) {
+		this.id = id;
+		this.userType = userType;
+		this.permissions = EnumSet.noneOf(Permission.class);
+		initPermissions();
+	}
+
+	private void initPermissions() {
+		switch (userType) {
+			case BUYER:
+				permissions.add(Permission.BUYER);
+				break;
+			case SELLER:
+				permissions.add(Permission.SELLER);
+				break;
+			case ADMIN:
+				permissions.addAll(EnumSet.allOf(Permission.class));
+				break;
+		}
+	}
+
+	public boolean isAdmin() {
+		return userType == UserType.ADMIN;
+	}
+
+	public boolean hasPermission(Permission currentPermission) {
+		Assert.notNull(currentPermission, "currentPermission은 필수입니다.");
+
+		if (permissions.contains(currentPermission)) {
+			return true;
+		}
+
+		throw new IllegalArgumentException("권한이 없습니다.");
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/context/SecurityPrincipalHolder.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/context/SecurityPrincipalHolder.java
@@ -3,6 +3,8 @@ package shop.sendbox.sendbox.security.auth.context;
 import org.springframework.stereotype.Component;
 
 import shop.sendbox.sendbox.security.auth.UserPrincipal;
+import shop.sendbox.sendbox.security.auth.exception.UserPrincipalNotSetException;
+import shop.sendbox.sendbox.security.auth.exception.UserPrincipalRequiredException;
 
 @Component
 public class SecurityPrincipalHolder {
@@ -11,7 +13,7 @@ public class SecurityPrincipalHolder {
 
 	public void setContext(UserPrincipal user) {
 		if (user == null) {
-			throw new IllegalArgumentException("UserPrincipal은 필수입니다.");
+			throw new UserPrincipalRequiredException("UserPrincipal은 필수입니다.");
 		}
 		userContext.set(user);
 	}
@@ -19,7 +21,7 @@ public class SecurityPrincipalHolder {
 	public UserPrincipal getContext() {
 		UserPrincipal user = userContext.get();
 		if (user == null) {
-			throw new IllegalStateException("UserPrincipal이 설정되지 않았습니다.");
+			throw new UserPrincipalNotSetException("UserPrincipal이 설정되지 않았습니다.");
 		}
 		return user;
 	}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/context/SecurityPrincipalHolder.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/context/SecurityPrincipalHolder.java
@@ -1,0 +1,30 @@
+package shop.sendbox.sendbox.security.auth.context;
+
+import org.springframework.stereotype.Component;
+
+import shop.sendbox.sendbox.security.auth.UserPrincipal;
+
+@Component
+public class SecurityPrincipalHolder {
+
+	private final ThreadLocal<UserPrincipal> userContext = new ThreadLocal<>();
+
+	public void setContext(UserPrincipal user) {
+		if (user == null) {
+			throw new IllegalArgumentException("UserPrincipal은 필수입니다.");
+		}
+		userContext.set(user);
+	}
+
+	public UserPrincipal getContext() {
+		UserPrincipal user = userContext.get();
+		if (user == null) {
+			throw new IllegalStateException("UserPrincipal이 설정되지 않았습니다.");
+		}
+		return user;
+	}
+
+	public void clear() {
+		userContext.remove();
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/exception/AuthenticationException.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/exception/AuthenticationException.java
@@ -1,0 +1,8 @@
+package shop.sendbox.sendbox.security.auth.exception;
+
+public class AuthenticationException extends RuntimeException {
+
+	public AuthenticationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/exception/AuthorizationException.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/exception/AuthorizationException.java
@@ -1,0 +1,8 @@
+package shop.sendbox.sendbox.security.auth.exception;
+
+public class AuthorizationException extends RuntimeException {
+
+	public AuthorizationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/exception/UserPrincipalNotSetException.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/exception/UserPrincipalNotSetException.java
@@ -1,0 +1,7 @@
+package shop.sendbox.sendbox.security.auth.exception;
+
+public class UserPrincipalNotSetException extends IllegalStateException {
+	public UserPrincipalNotSetException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/exception/UserPrincipalRequiredException.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/exception/UserPrincipalRequiredException.java
@@ -1,0 +1,7 @@
+package shop.sendbox.sendbox.security.auth.exception;
+
+public class UserPrincipalRequiredException extends IllegalArgumentException {
+	public UserPrincipalRequiredException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/filter/ExceptionTranslationFilter.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/filter/ExceptionTranslationFilter.java
@@ -1,0 +1,48 @@
+package shop.sendbox.sendbox.security.auth.filter;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import shop.sendbox.sendbox.api.ErrorResponse;
+import shop.sendbox.sendbox.security.auth.exception.AuthenticationException;
+import shop.sendbox.sendbox.security.auth.exception.AuthorizationException;
+
+@RequiredArgsConstructor
+public class ExceptionTranslationFilter implements Filter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
+		IOException, ServletException {
+
+		try {
+			chain.doFilter(request, response);
+		} catch (AuthenticationException e) {
+			sendErrorResponse((HttpServletResponse)response, ErrorResponse.unauthorized());
+		} catch (AuthorizationException e) {
+			sendErrorResponse((HttpServletResponse)response, ErrorResponse.accessDenied());
+		} catch (Exception e) {
+			sendErrorResponse((HttpServletResponse)response, ErrorResponse.serverError());
+		}
+	}
+
+	private void sendErrorResponse(HttpServletResponse response, ErrorResponse errorResponse) throws IOException {
+		if (!response.isCommitted()) {
+			response.setStatus(errorResponse.statusCode());
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+			response.setCharacterEncoding("UTF-8");
+			response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+		}
+	}
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/filter/SessionAuthenticationFilter.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/filter/SessionAuthenticationFilter.java
@@ -19,6 +19,7 @@ import shop.sendbox.sendbox.security.auth.exception.AuthenticationException;
 @RequiredArgsConstructor
 public class SessionAuthenticationFilter implements Filter {
 
+	public static final String USER_PRINCIPAL = "userPrincipal";
 	private final SecurityPrincipalHolder securityPrincipalHolder;
 
 	@Override
@@ -53,7 +54,7 @@ public class SessionAuthenticationFilter implements Filter {
 			throw new AuthenticationException("로그인이 필요합니다.");
 		}
 
-		Object attr = session.getAttribute("userPrincipal");
+		Object attr = session.getAttribute(USER_PRINCIPAL);
 		if (!(attr instanceof UserPrincipal)) {
 			throw new AuthenticationException("유효한 사용자 정보가 아닙니다.");
 		}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/filter/SessionAuthenticationFilter.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/filter/SessionAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package shop.sendbox.sendbox.security.auth.filter;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import shop.sendbox.sendbox.security.auth.ApiEndpointEnum;
+import shop.sendbox.sendbox.security.auth.Permission;
+import shop.sendbox.sendbox.security.auth.UserPrincipal;
+import shop.sendbox.sendbox.security.auth.context.SecurityPrincipalHolder;
+import shop.sendbox.sendbox.security.auth.exception.AuthenticationException;
+
+@RequiredArgsConstructor
+public class SessionAuthenticationFilter implements Filter {
+
+	private final SecurityPrincipalHolder securityPrincipalHolder;
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+		throws IOException, ServletException {
+
+		HttpServletRequest httpRequest = (HttpServletRequest)request;
+		String requestUri = httpRequest.getRequestURI();
+		String method = httpRequest.getMethod();
+
+		try {
+			Permission endpoint = ApiEndpointEnum.matchEndpoint(requestUri, method);
+
+			if (endpoint.doesNotRequireAuth()) {
+				chain.doFilter(request, response);
+				return;
+			}
+
+			UserPrincipal extractedUserPrincipal = extractUserPrincipal(httpRequest);
+
+			securityPrincipalHolder.setContext(extractedUserPrincipal);
+
+			chain.doFilter(request, response);
+		} finally {
+			securityPrincipalHolder.clear();
+		}
+	}
+
+	private UserPrincipal extractUserPrincipal(HttpServletRequest req) {
+		HttpSession session = req.getSession(false);
+		if (session == null) {
+			throw new AuthenticationException("로그인이 필요합니다.");
+		}
+
+		Object attr = session.getAttribute("userPrincipal");
+		if (!(attr instanceof UserPrincipal)) {
+			throw new AuthenticationException("유효한 사용자 정보가 아닙니다.");
+		}
+		return (UserPrincipal)attr;
+	}
+
+}

--- a/src/main/java/shop/sendbox/sendbox/security/auth/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/shop/sendbox/sendbox/security/auth/interceptor/AuthorizationInterceptor.java
@@ -1,0 +1,41 @@
+package shop.sendbox.sendbox.security.auth.interceptor;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import shop.sendbox.sendbox.security.auth.ApiEndpointEnum;
+import shop.sendbox.sendbox.security.auth.Permission;
+import shop.sendbox.sendbox.security.auth.UserPrincipal;
+import shop.sendbox.sendbox.security.auth.context.SecurityPrincipalHolder;
+import shop.sendbox.sendbox.security.auth.exception.AuthorizationException;
+
+@RequiredArgsConstructor
+public class AuthorizationInterceptor implements HandlerInterceptor {
+
+	private final SecurityPrincipalHolder securityPrincipalHolder;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+		throws Exception {
+
+		String requestUri = request.getRequestURI();
+		String method = request.getMethod();
+
+		Permission currentPermission = ApiEndpointEnum.matchEndpoint(requestUri, method);
+
+		if (currentPermission.doesNotRequireAuth()) {
+			return true;
+		}
+
+		UserPrincipal user = securityPrincipalHolder.getContext();
+
+		if (user == null) {
+			throw new AuthorizationException("로그인이 필요합니다.");
+		}
+
+		return user.hasPermission(currentPermission);
+	}
+
+}

--- a/src/main/java/shop/sendbox/sendbox/security/crypto/config/SecurityConfig.java
+++ b/src/main/java/shop/sendbox/sendbox/security/crypto/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package shop.sendbox.sendbox.security.config;
+package shop.sendbox.sendbox.security.crypto.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;

--- a/src/main/java/shop/sendbox/sendbox/security/crypto/dto/PasswordData.java
+++ b/src/main/java/shop/sendbox/sendbox/security/crypto/dto/PasswordData.java
@@ -1,4 +1,4 @@
-package shop.sendbox.sendbox.security.dto;
+package shop.sendbox.sendbox.security.crypto.dto;
 
 public record PasswordData(String hashedPassword, String salt) {
 }

--- a/src/main/java/shop/sendbox/sendbox/security/crypto/hashing/Sha256HashingService.java
+++ b/src/main/java/shop/sendbox/sendbox/security/crypto/hashing/Sha256HashingService.java
@@ -8,7 +8,7 @@ import java.util.Base64;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
-import shop.sendbox.sendbox.security.config.SecurityConfig;
+import shop.sendbox.sendbox.security.crypto.config.SecurityConfig;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/shop/sendbox/sendbox/security/crypto/service/SecurityService.java
+++ b/src/main/java/shop/sendbox/sendbox/security/crypto/service/SecurityService.java
@@ -1,6 +1,6 @@
-package shop.sendbox.sendbox.security.service;
+package shop.sendbox.sendbox.security.crypto.service;
 
-import shop.sendbox.sendbox.security.dto.PasswordData;
+import shop.sendbox.sendbox.security.crypto.dto.PasswordData;
 
 public interface SecurityService {
 	String encryptText(String plainText);

--- a/src/main/java/shop/sendbox/sendbox/security/crypto/service/SecurityServiceImpl.java
+++ b/src/main/java/shop/sendbox/sendbox/security/crypto/service/SecurityServiceImpl.java
@@ -1,11 +1,11 @@
-package shop.sendbox.sendbox.security.service;
+package shop.sendbox.sendbox.security.crypto.service;
 
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import shop.sendbox.sendbox.security.crypto.dto.PasswordData;
 import shop.sendbox.sendbox.security.crypto.hashing.HashingService;
 import shop.sendbox.sendbox.security.crypto.symmetric.SymmetricCryptoService;
-import shop.sendbox.sendbox.security.dto.PasswordData;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/shop/sendbox/sendbox/security/crypto/symmetric/AesEncryptService.java
+++ b/src/main/java/shop/sendbox/sendbox/security/crypto/symmetric/AesEncryptService.java
@@ -13,7 +13,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
-import shop.sendbox.sendbox.security.config.SecurityConfig;
+import shop.sendbox.sendbox.security.crypto.config.SecurityConfig;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/shop/sendbox/sendbox/seller/repository/SellerRepository.java
+++ b/src/main/java/shop/sendbox/sendbox/seller/repository/SellerRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import shop.sendbox.sendbox.seller.entity.Seller;
 
 public interface SellerRepository extends JpaRepository<Seller, Long> {
-    boolean existsByBusinessNumber(String businessNumber);
-    Optional<Seller> findByTaxEmail(String taxEmail);
-    boolean existsByTaxEmail(String taxEmail);
+	boolean existsByBusinessNumber(String businessNumber);
+
+	Optional<Seller> findByTaxEmail(String taxEmail);
+
+	boolean existsByTaxEmail(String taxEmail);
 }

--- a/src/main/java/shop/sendbox/sendbox/seller/service/SellerCreateCommand.java
+++ b/src/main/java/shop/sendbox/sendbox/seller/service/SellerCreateCommand.java
@@ -1,5 +1,5 @@
 package shop.sendbox.sendbox.seller.service;
 
-public record SellerCreateCommand(String password, String name, String businessNumber, String phoneNumber,
-	String taxEmail) {
+public record SellerCreateCommand(String password, String name, String businessNumber,
+	String phoneNumber, String taxEmail) {
 }

--- a/src/main/java/shop/sendbox/sendbox/seller/service/SellerService.java
+++ b/src/main/java/shop/sendbox/sendbox/seller/service/SellerService.java
@@ -8,8 +8,8 @@ import shop.sendbox.sendbox.login.LoginHandler;
 import shop.sendbox.sendbox.login.LoginResponse;
 import shop.sendbox.sendbox.login.LoginUser;
 import shop.sendbox.sendbox.login.UserType;
-import shop.sendbox.sendbox.security.dto.PasswordData;
-import shop.sendbox.sendbox.security.service.SecurityService;
+import shop.sendbox.sendbox.security.crypto.dto.PasswordData;
+import shop.sendbox.sendbox.security.crypto.service.SecurityService;
 import shop.sendbox.sendbox.seller.entity.Seller;
 import shop.sendbox.sendbox.seller.repository.SellerRepository;
 
@@ -17,72 +17,72 @@ import shop.sendbox.sendbox.seller.repository.SellerRepository;
 @RequiredArgsConstructor
 public class SellerService implements LoginHandler {
 
-    private final SellerRepository sellerRepository;
-    private final SecurityService securityService;
+	private final SellerRepository sellerRepository;
+	private final SecurityService securityService;
 
-    @Transactional
-    public SellerCreateResult createSeller(SellerCreateCommand command) {
-        validateBusinessNumberNotDuplicate(command);
-        validateTaxEmailNotDuplicate(command);
+	@Transactional
+	public SellerCreateResult createSeller(SellerCreateCommand command) {
+		validateBusinessNumberNotDuplicate(command);
+		validateTaxEmailNotDuplicate(command);
 
-        String encryptedPhoneNumber = securityService.encryptText(command.phoneNumber());
-        String encryptedTaxEmail = securityService.encryptText(command.taxEmail());
-        String encryptedBusinessNumber = securityService.encryptText(command.businessNumber());
+		String encryptedPhoneNumber = securityService.encryptText(command.phoneNumber());
+		String encryptedTaxEmail = securityService.encryptText(command.taxEmail());
+		String encryptedBusinessNumber = securityService.encryptText(command.businessNumber());
 
-        PasswordData passwordData = securityService.encryptPassword(command.password());
+		PasswordData passwordData = securityService.encryptPassword(command.password());
 
-        Seller seller = Seller.create(passwordData.hashedPassword(), passwordData.salt(), command.name(),
-            encryptedBusinessNumber, encryptedPhoneNumber, encryptedTaxEmail);
+		Seller seller = Seller.create(passwordData.hashedPassword(), passwordData.salt(), command.name(),
+			encryptedBusinessNumber, encryptedPhoneNumber, encryptedTaxEmail);
 
-        Seller savedSeller = sellerRepository.save(seller);
+		Seller savedSeller = sellerRepository.save(seller);
 
-        String decryptedPhoneNumber = securityService.decryptText(savedSeller.getPhoneNumber());
-        String decryptedTaxEmail = securityService.decryptText(savedSeller.getTaxEmail());
+		String decryptedPhoneNumber = securityService.decryptText(savedSeller.getPhoneNumber());
+		String decryptedTaxEmail = securityService.decryptText(savedSeller.getTaxEmail());
 
-        return SellerCreateResult.of(
-            savedSeller, decryptedPhoneNumber, decryptedTaxEmail
-        );
-    }
+		return SellerCreateResult.of(
+			savedSeller, decryptedPhoneNumber, decryptedTaxEmail
+		);
+	}
 
-    private void validateBusinessNumberNotDuplicate(SellerCreateCommand command) {
-        String encryptedBusinessNumber = securityService.encryptText(command.businessNumber());
-        if (sellerRepository.existsByBusinessNumber(encryptedBusinessNumber)) {
-            throw new IllegalArgumentException("이미 등록된 사업자번호입니다.");
-        }
-    }
-    
-    private void validateTaxEmailNotDuplicate(SellerCreateCommand command) {
-        String encryptedTaxEmail = securityService.encryptText(command.taxEmail());
-        if (sellerRepository.existsByTaxEmail(encryptedTaxEmail)) {
-            throw new IllegalArgumentException("이미 등록된 세금 계산서용 이메일입니다.");
-        }
-    }
-    
-    @Override
-    @Transactional(readOnly = true)
-    public LoginResponse login(final LoginUser user) {
-        // 이메일 암호화하여 회원 조회
-        String encryptedEmail = securityService.encryptText(user.email());
+	private void validateBusinessNumberNotDuplicate(SellerCreateCommand command) {
+		String encryptedBusinessNumber = securityService.encryptText(command.businessNumber());
+		if (sellerRepository.existsByBusinessNumber(encryptedBusinessNumber)) {
+			throw new IllegalArgumentException("이미 등록된 사업자번호입니다.");
+		}
+	}
 
-        Seller foundSeller = sellerRepository.findByTaxEmail(encryptedEmail)
-            .orElseThrow(() -> new IllegalArgumentException("해당 이메일로 가입된 판매자가 없습니다."));
+	private void validateTaxEmailNotDuplicate(SellerCreateCommand command) {
+		String encryptedTaxEmail = securityService.encryptText(command.taxEmail());
+		if (sellerRepository.existsByTaxEmail(encryptedTaxEmail)) {
+			throw new IllegalArgumentException("이미 등록된 세금 계산서용 이메일입니다.");
+		}
+	}
 
-        // 비밀번호 검증
-        boolean isPasswordValid = securityService.verifyPassword(
-            user.password(),
-            foundSeller.getPassword(),
-            foundSeller.getSalt()
-        );
+	@Override
+	@Transactional(readOnly = true)
+	public LoginResponse login(final LoginUser user) {
+		// 이메일 암호화하여 회원 조회
+		String encryptedEmail = securityService.encryptText(user.email());
 
-        if (!isPasswordValid) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
+		Seller foundSeller = sellerRepository.findByTaxEmail(encryptedEmail)
+			.orElseThrow(() -> new IllegalArgumentException("해당 이메일로 가입된 판매자가 없습니다."));
 
-        return LoginResponse.of(foundSeller, user.email());
-    }
+		// 비밀번호 검증
+		boolean isPasswordValid = securityService.verifyPassword(
+			user.password(),
+			foundSeller.getPassword(),
+			foundSeller.getSalt()
+		);
 
-    @Override
-    public boolean supports(UserType userType) {
-        return UserType.SELLER == userType;
-    }
+		if (!isPasswordValid) {
+			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+		}
+
+		return LoginResponse.of(foundSeller, user.email());
+	}
+
+	@Override
+	public boolean supports(UserType userType) {
+		return UserType.SELLER == userType;
+	}
 }

--- a/src/main/java/shop/sendbox/sendbox/seller/service/SellerService.java
+++ b/src/main/java/shop/sendbox/sendbox/seller/service/SellerService.java
@@ -23,13 +23,13 @@ public class SellerService implements LoginHandler {
 	@Transactional
 	public SellerCreateResult createSeller(SellerCreateCommand command) {
 		validateUniqueBusinessNumber(command);
-        validateTaxEmailNotDuplicate(command);
+		validateTaxEmailNotDuplicate(command);
 
 		String encryptedPhoneNumber = securityService.encryptText(command.phoneNumber());
 		String encryptedTaxEmail = securityService.encryptText(command.taxEmail());
 		String encryptedBusinessNumber = securityService.encryptText(command.businessNumber());
 
-        PasswordData passwordData = securityService.encryptPassword(command.password());
+		PasswordData passwordData = securityService.encryptPassword(command.password());
 
 		Seller seller = Seller.create(passwordData.hashedPassword(), passwordData.salt(), command.name(),
 			encryptedBusinessNumber, encryptedPhoneNumber, encryptedTaxEmail);
@@ -51,18 +51,18 @@ public class SellerService implements LoginHandler {
 		}
 	}
 
-    private void validateTaxEmailNotDuplicate(SellerCreateCommand command) {
-        String encryptedTaxEmail = securityService.encryptText(command.taxEmail());
-        if (sellerRepository.existsByTaxEmail(encryptedTaxEmail)) {
-            throw new IllegalArgumentException("이미 등록된 세금 계산서용 이메일입니다.");
-        }
-    }
+	private void validateTaxEmailNotDuplicate(SellerCreateCommand command) {
+		String encryptedTaxEmail = securityService.encryptText(command.taxEmail());
+		if (sellerRepository.existsByTaxEmail(encryptedTaxEmail)) {
+			throw new IllegalArgumentException("이미 등록된 세금 계산서용 이메일입니다.");
+		}
+	}
 
-    @Override
-    @Transactional(readOnly = true)
-    public LoginResponse login(final LoginUser user) {
-        // 이메일 암호화하여 회원 조회
-        String encryptedEmail = securityService.encryptText(user.email());
+	@Override
+	@Transactional(readOnly = true)
+	public LoginResponse login(final LoginUser user) {
+		// 이메일 암호화하여 회원 조회
+		String encryptedEmail = securityService.encryptText(user.email());
 
 		Seller foundSeller = sellerRepository.findByTaxEmail(encryptedEmail)
 			.orElseThrow(() -> new IllegalArgumentException("해당 이메일로 가입된 판매자가 없습니다."));

--- a/src/test/java/shop/sendbox/sendbox/api/ApiControllerAdviceTest.java
+++ b/src/test/java/shop/sendbox/sendbox/api/ApiControllerAdviceTest.java
@@ -3,35 +3,30 @@ package shop.sendbox.sendbox.api;
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
-import java.sql.SQLException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestTemplate;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MockMvcBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import shop.sendbox.sendbox.login.LoginController;
 import shop.sendbox.sendbox.login.LoginCreateRequest;
 import shop.sendbox.sendbox.login.LoginService;
 import shop.sendbox.sendbox.login.UserType;
+import shop.sendbox.sendbox.testsupport.config.TestHolderConfig;
 
 @WebMvcTest(controllers = {
 	LoginController.class
 })
+@Import(TestHolderConfig.class)
 class ApiControllerAdviceTest {
 
 	@Autowired

--- a/src/test/java/shop/sendbox/sendbox/api/ApiControllerAdviceTest.java
+++ b/src/test/java/shop/sendbox/sendbox/api/ApiControllerAdviceTest.java
@@ -1,5 +1,6 @@
 package shop.sendbox.sendbox.api;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
@@ -21,11 +22,13 @@ import shop.sendbox.sendbox.login.LoginController;
 import shop.sendbox.sendbox.login.LoginCreateRequest;
 import shop.sendbox.sendbox.login.LoginService;
 import shop.sendbox.sendbox.login.UserType;
+import shop.sendbox.sendbox.security.auth.UserPrincipal;
+import shop.sendbox.sendbox.security.auth.context.SecurityPrincipalHolder;
+import shop.sendbox.sendbox.security.auth.exception.UserPrincipalNotSetException;
+import shop.sendbox.sendbox.security.auth.exception.UserPrincipalRequiredException;
 import shop.sendbox.sendbox.testsupport.config.TestHolderConfig;
 
-@WebMvcTest(controllers = {
-	LoginController.class
-})
+@WebMvcTest(controllers = {LoginController.class})
 @Import(TestHolderConfig.class)
 class ApiControllerAdviceTest {
 
@@ -47,13 +50,57 @@ class ApiControllerAdviceTest {
 		Mockito.when(loginService.login(any())).thenThrow(new IllegalArgumentException("비밀번호가 일치하지 않습니다."));
 
 		// when & then
-		mockMvc.perform(
-				MockMvcRequestBuilders.post("/login")
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest)))
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest)))
 			.andDo(print())
 			.andExpect(MockMvcResultMatchers.status().isBadRequest())
 			.andExpect(MockMvcResultMatchers.jsonPath("$.message").isString());
 	}
 
+	@DisplayName("UserPrincipal이 null일 경우 UserPrincipalRequiredException이 발생합니다.")
+	void throwsUserPrincipalRequiredExceptionWhenUserIsNull() {
+		// given
+		SecurityPrincipalHolder holder = new SecurityPrincipalHolder();
+
+		// when & then
+		assertThrows(UserPrincipalRequiredException.class, () -> holder.setContext(null));
+	}
+
+	@DisplayName("UserPrincipal이 설정되지 않은 상태에서 getContext 호출 시 UserPrincipalNotSetException이 발생합니다.")
+	void throwsUserPrincipalNotSetExceptionWhenContextIsNotSet() {
+		// given
+		SecurityPrincipalHolder holder = new SecurityPrincipalHolder();
+
+		// when & then
+		assertThrows(UserPrincipalNotSetException.class, holder::getContext);
+	}
+
+	@DisplayName("UserPrincipal을 설정하고 정상적으로 가져올 수 있습니다.")
+	void successfullySetsAndGetsUserPrincipal() {
+		// given
+		SecurityPrincipalHolder holder = new SecurityPrincipalHolder();
+		UserPrincipal userPrincipal = new UserPrincipal("testUser", UserType.BUYER);
+
+		// when
+		holder.setContext(userPrincipal);
+		UserPrincipal result = holder.getContext();
+
+		// then
+		assertEquals(userPrincipal, result);
+	}
+
+	@DisplayName("clear 호출 후 UserPrincipal이 제거됩니다.")
+	void clearsUserPrincipalSuccessfully() {
+		// given
+		SecurityPrincipalHolder holder = new SecurityPrincipalHolder();
+		UserPrincipal userPrincipal = new UserPrincipal("testUser", UserType.BUYER);
+		holder.setContext(userPrincipal);
+
+		// when
+		holder.clear();
+
+		// then
+		assertThrows(UserPrincipalNotSetException.class, holder::getContext);
+	}
 }

--- a/src/test/java/shop/sendbox/sendbox/api/ErrorResponseTest.java
+++ b/src/test/java/shop/sendbox/sendbox/api/ErrorResponseTest.java
@@ -1,0 +1,83 @@
+package shop.sendbox.sendbox.api;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ErrorResponseTest {
+
+	@Test
+	@DisplayName("인증되지 않은 요청에 대한 에러 응답을 생성합니다")
+	void unauthorized_CreatesUnauthorizedErrorResponse() {
+		// when
+		ErrorResponse response = ErrorResponse.unauthorized();
+
+		// then
+		assertThat(response.statusCode()).isEqualTo(401);
+		assertThat(response.message()).isEqualTo("UNAUTHORIZED");
+		assertThat(response.errorCode()).isEqualTo("AUTH_001");
+		assertThat(response.errorDetail()).isEqualTo("이 리소스에 접근하기 위해서는 인증이 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("접근 거부된 요청에 대한 에러 응답을 생성합니다")
+	void accessDenied_CreatesAccessDeniedErrorResponse() {
+		// when
+		ErrorResponse response = ErrorResponse.accessDenied();
+
+		// then
+		assertThat(response.statusCode()).isEqualTo(403);
+		assertThat(response.message()).isEqualTo("ACCESS_DENIED");
+		assertThat(response.errorCode()).isEqualTo("AUTH_003");
+		assertThat(response.errorDetail()).isEqualTo("이 리소스에 접근할 권한이 없습니다.");
+	}
+
+	@Test
+	@DisplayName("서버 오류에 대한 에러 응답을 생성합니다")
+	void serverError_CreatesServerErrorResponse() {
+		// when
+		ErrorResponse response = ErrorResponse.serverError();
+
+		// then
+		assertThat(response.statusCode()).isEqualTo(500);
+		assertThat(response.message()).isEqualTo("SERVER_ERROR");
+		assertThat(response.errorCode()).isEqualTo("SYS_001");
+		assertThat(response.errorDetail()).isEqualTo("예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요.");
+	}
+
+	@Test
+	@DisplayName("잘못된 요청에 대한 에러 응답을 생성합니다")
+	void badRequest_CreatesBadRequestErrorResponse() {
+		// given
+		String errorMessage = "유효하지 않은 입력입니다";
+
+		// when
+		ErrorResponse response = ErrorResponse.badRequest(errorMessage);
+
+		// then
+		assertThat(response.statusCode()).isEqualTo(400);
+		assertThat(response.message()).isEqualTo("BAD_REQUEST");
+		assertThat(response.errorCode()).isEqualTo("SYS_002");
+		assertThat(response.errorDetail()).isEqualTo(errorMessage);
+	}
+
+	@Test
+	@DisplayName("사용자 정의 에러 응답을 생성합니다")
+	void of_CreatesCustomErrorResponse() {
+		// given
+		int statusCode = 422;
+		String message = "VALIDATION_ERROR";
+		String errorCode = "VAL_001";
+		String errorDetail = "필수 입력값이 누락되었습니다";
+
+		// when
+		ErrorResponse response = ErrorResponse.of(statusCode, message, errorCode, errorDetail);
+
+		// then
+		assertThat(response.statusCode()).isEqualTo(statusCode);
+		assertThat(response.message()).isEqualTo(message);
+		assertThat(response.errorCode()).isEqualTo(errorCode);
+		assertThat(response.errorDetail()).isEqualTo(errorDetail);
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/buyer/BuyerControllerTest.java
+++ b/src/test/java/shop/sendbox/sendbox/buyer/BuyerControllerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -17,10 +18,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import shop.sendbox.sendbox.buyer.controller.BuyerController;
 import shop.sendbox.sendbox.buyer.controller.BuyerCreateRequest;
 import shop.sendbox.sendbox.buyer.service.BuyerService;
+import shop.sendbox.sendbox.testsupport.config.TestHolderConfig;
 
 @WebMvcTest(controllers = {
 	BuyerController.class,
 })
+@Import(TestHolderConfig.class)
 class BuyerControllerTest {
 
 	@Autowired

--- a/src/test/java/shop/sendbox/sendbox/config/WebMvcConfigIntegrationTest.java
+++ b/src/test/java/shop/sendbox/sendbox/config/WebMvcConfigIntegrationTest.java
@@ -1,0 +1,113 @@
+package shop.sendbox.sendbox.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import jakarta.servlet.Filter;
+import shop.sendbox.sendbox.security.auth.filter.ExceptionTranslationFilter;
+import shop.sendbox.sendbox.security.auth.filter.SessionAuthenticationFilter;
+import shop.sendbox.sendbox.security.auth.interceptor.AuthorizationInterceptor;
+
+@SpringBootTest
+@ContextConfiguration
+class WebMvcConfigIntegrationTest {
+
+	@Autowired
+	private WebApplicationContext webApplicationContext;
+
+	@Test
+	@DisplayName("필터가 올바른 순서로 등록됩니다")
+	void filterRegistrationOrder() {
+		// Given
+		Map<String, FilterRegistrationBean> filterBeans = webApplicationContext.getBeansOfType(
+			FilterRegistrationBean.class);
+
+		// When
+		FilterRegistrationBean<?> exceptionFilter = findFilterByType(filterBeans, ExceptionTranslationFilter.class);
+		FilterRegistrationBean<?> authFilter = findFilterByType(filterBeans, SessionAuthenticationFilter.class);
+
+		// Then
+		assertThat(exceptionFilter).isNotNull();
+		assertThat(authFilter).isNotNull();
+
+		assertThat(exceptionFilter.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
+		assertThat(authFilter.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE + 1);
+
+		assertThat(exceptionFilter.getUrlPatterns()).containsExactly("/*");
+		assertThat(authFilter.getUrlPatterns()).containsExactly("/*");
+	}
+
+	@Test
+	@DisplayName("필터 order 번호에 중복이 없습니다")
+	void filterOrderUniqueness() {
+		// Given
+		Map<String, FilterRegistrationBean> filterBeans = webApplicationContext.getBeansOfType(
+			FilterRegistrationBean.class);
+
+		// When
+		Map<Integer, List<FilterRegistrationBean>> orderGroups = filterBeans.values().stream()
+			.collect(Collectors.groupingBy(bean -> bean.getOrder()));
+
+		// Then
+		orderGroups.forEach((order, filters) -> {
+			assertThat(filters).as("Order " + order + "에 대해 하나의 필터만 있어야 합니다").hasSize(1);
+		});
+	}
+
+	@Test
+	@DisplayName("인터셉터 간에 order 번호 중복이 없습니다")
+	void interceptorOrderUniqueness() throws Exception {
+		// given
+		RequestMappingHandlerMapping mapping = webApplicationContext.getBean(RequestMappingHandlerMapping.class);
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/buyers");
+
+		// when
+		HandlerExecutionChain handlerChain = mapping.getHandler(request);
+		Assertions.assertNotNull(handlerChain);
+		List<HandlerInterceptor> interceptors = Arrays.asList(Objects.requireNonNull(handlerChain.getInterceptors()));
+
+		// then
+		List<? extends Class<?>> actualInterceptorClasses = interceptors.stream()
+			.map(Object::getClass)
+			.toList();
+
+		List<Class<? extends Object>> expectedOrder = List.of(
+			AuthorizationInterceptor.class
+		);
+
+		for (int i = 0; i < expectedOrder.size(); i++) {
+			Class<? extends Object> expectedClass = expectedOrder.get(i);
+			assertThat(actualInterceptorClasses)
+				.as("인덱스 " + i + "에 " + expectedClass.getSimpleName() + " 클래스가 있어야 합니다")
+				.element(i)
+				.isEqualTo(expectedClass);
+		}
+	}
+
+	private FilterRegistrationBean<?> findFilterByType(Map<String, FilterRegistrationBean> filterBeans,
+		Class<? extends Filter> filterType) {
+		return filterBeans.values().stream()
+			.filter(bean -> filterType.isInstance(bean.getFilter()))
+			.findFirst()
+			.orElse(null);
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/config/WebMvcConfigTest.java
+++ b/src/test/java/shop/sendbox/sendbox/config/WebMvcConfigTest.java
@@ -1,0 +1,89 @@
+package shop.sendbox.sendbox.config;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import shop.sendbox.sendbox.security.auth.context.SecurityPrincipalHolder;
+import shop.sendbox.sendbox.security.auth.filter.ExceptionTranslationFilter;
+import shop.sendbox.sendbox.security.auth.filter.SessionAuthenticationFilter;
+import shop.sendbox.sendbox.security.auth.interceptor.AuthorizationInterceptor;
+
+@ExtendWith(MockitoExtension.class)
+class WebMvcConfigTest {
+
+	@Mock
+	private ObjectMapper objectMapper;
+
+	@Mock
+	private SecurityPrincipalHolder securityPrincipalHolder;
+
+	@InjectMocks
+	private WebMvcConfig webMvcConfig;
+
+	@Test
+	@DisplayName("인가 인터셉터가 정상적으로 생성됩니다")
+	void authorizationInterceptorCreation() {
+		AuthorizationInterceptor interceptor = webMvcConfig.authorizationInterceptor();
+
+		assertThat(interceptor).isNotNull();
+	}
+
+	@Test
+	@DisplayName("인가 인터셉터는 모든 경로에 등록됩니다")
+	void interceptorRegistration() {
+		// Given
+		InterceptorRegistry registry = mock(InterceptorRegistry.class);
+		InterceptorRegistration registration = mock(InterceptorRegistration.class);
+		when(registry.addInterceptor(any(AuthorizationInterceptor.class))).thenReturn(registration);
+
+		// When
+		webMvcConfig.addInterceptors(registry);
+
+		// Then
+		verify(registry).addInterceptor(any(AuthorizationInterceptor.class));
+		verify(registration).addPathPatterns("/**");
+	}
+
+	@Test
+	@DisplayName("예외 필터는 가장 높은 우선순위로 등록됩니다")
+	void exceptionFilterRegistration() {
+		FilterRegistrationBean<ExceptionTranslationFilter> registration = webMvcConfig.exceptionTranslationFilter();
+
+		assertThat(registration).isNotNull();
+		assertThat(registration.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
+		assertThat(registration.getUrlPatterns()).containsExactly("/*");
+	}
+
+	@Test
+	@DisplayName("인증 필터는 예외 필터보다 나중에 등록됩니다")
+	void authFilterRegistration() {
+		FilterRegistrationBean<SessionAuthenticationFilter> registration = webMvcConfig.authenticationFilter();
+
+		assertThat(registration).isNotNull();
+		assertThat(registration.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE + 1);
+		assertThat(registration.getUrlPatterns()).containsExactly("/*");
+	}
+
+	@Test
+	@DisplayName("필터 등록 순서는 충돌이 없습니다")
+	void filterOrderNoConflict() {
+		FilterRegistrationBean<ExceptionTranslationFilter> exceptionFilter = webMvcConfig.exceptionTranslationFilter();
+		FilterRegistrationBean<SessionAuthenticationFilter> authFilter = webMvcConfig.authenticationFilter();
+
+		assertThat(exceptionFilter.getOrder()).isNotEqualTo(authFilter.getOrder());
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/coupon/controller/CouponControllerTest.java
+++ b/src/test/java/shop/sendbox/sendbox/coupon/controller/CouponControllerTest.java
@@ -11,8 +11,12 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -20,8 +24,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import shop.sendbox.sendbox.coupon.entity.CouponType;
 import shop.sendbox.sendbox.coupon.service.CouponService;
+import shop.sendbox.sendbox.testsupport.config.TestHolderConfig;
+import shop.sendbox.sendbox.testsupport.config.TestNoWebMvcConfig;
 
-@WebMvcTest(controllers = {CouponController.class})
+@WebMvcTest(controllers = {
+	CouponController.class}, excludeFilters =
+	@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+		shop.sendbox.sendbox.config.WebMvcConfig.class}))
+@Import({TestHolderConfig.class, TestNoWebMvcConfig.class})
+@AutoConfigureMockMvc(addFilters = false)
 class CouponControllerTest {
 
 	@Autowired
@@ -55,7 +66,7 @@ class CouponControllerTest {
 	}
 
 	@Test
-	@DisplayName("쿠폰을 등록할때 판매자 정보")
+	@DisplayName("쿠폰을 정상적으로 등록한다")
 	void couponRegist() throws Exception {
 		// given
 		LocalDateTime startDateTime = LocalDateTime.of(2025, 3, 14, 1, 1);

--- a/src/test/java/shop/sendbox/sendbox/login/LoginControllerTest.java
+++ b/src/test/java/shop/sendbox/sendbox/login/LoginControllerTest.java
@@ -9,17 +9,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import shop.sendbox.sendbox.testsupport.config.TestHolderConfig;
 
 /*
 MVC 테스트와 관련된 컴포넌트만 등록합니다.
@@ -28,6 +30,7 @@ MVC 테스트와 관련된 컴포넌트만 등록합니다.
 컨트롤러 계층을 슬라이스 테스트 하고 싶을 때 사용합니다.
  */
 @WebMvcTest(controllers = {LoginController.class})
+@Import(TestHolderConfig.class)
 class LoginControllerTest {
 
 	@Autowired
@@ -57,167 +60,158 @@ class LoginControllerTest {
 		session = new MockHttpSession();
 	}
 
-	@Nested
-	@DisplayName("로그인 성공 테스트")
-	class LoginSuccess {
-		@Test
-		@DisplayName("회원가입된 구매자는 올바른 정보 입력시 로그인할 수 있습니다")
-		void loginTest() throws Exception {
-			// given
-			final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, validPassword, UserType.BUYER);
-			final LoginRequest loginRequest = createRequest.toServiceRequest();
-			final LoginResponse response = new LoginResponse(validUserId, validName, validEmail);
-			when(loginService.login(loginRequest)).thenReturn(response);
+	@Test
+	@DisplayName("로그인 성공: 회원가입된 구매자는 올바른 정보 입력시 로그인할 수 있습니다")
+	void loginTest() throws Exception {
+		// given
+		final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, validPassword, UserType.BUYER);
+		final LoginRequest loginRequest = createRequest.toServiceRequest();
+		final LoginResponse response = new LoginResponse(validUserId, validName, validEmail);
+		when(loginService.login(loginRequest)).thenReturn(response);
 
-			// when & then
-			mockMvc.perform(MockMvcRequestBuilders.post("/login")
-					.contentType(APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest))
-					.session(session))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.data.id").value(response.id()))
-				.andExpect(jsonPath("$.data.name").value(response.name()))
-				.andExpect(jsonPath("$.data.email").value(response.email()));
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest))
+				.session(session))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(response.id()))
+			.andExpect(jsonPath("$.data.name").value(response.name()))
+			.andExpect(jsonPath("$.data.email").value(response.email()));
 
-			assertThat(session.getAttribute("user")).isEqualTo(validUserId);
-		}
-
-		@Test
-		@DisplayName("회원가입된 판매자는 올바른 정보 입력시 로그인할 수 있습니다")
-		void loginSellerTest() throws Exception {
-			// given
-			final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, validPassword, UserType.SELLER);
-			final LoginRequest loginRequest = createRequest.toServiceRequest();
-			final LoginResponse response = new LoginResponse(validUserId, validName, validEmail);
-			when(loginService.login(loginRequest)).thenReturn(response);
-
-			// when & then
-			mockMvc.perform(MockMvcRequestBuilders.post("/login")
-					.contentType(APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest))
-					.session(session))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.data.id").value(response.id()))
-				.andExpect(jsonPath("$.data.name").value(response.name()))
-				.andExpect(jsonPath("$.data.email").value(response.email()));
-
-			assertThat(session.getAttribute("user")).isEqualTo(validUserId);
-		}
+		assertThat(session.getAttribute("user")).isEqualTo(validUserId);
 	}
 
-	@Nested
-	@DisplayName("로그인 실패 테스트")
-	class LoginFail {
-		@Test
-		@DisplayName("회원가입된 구매자는 올바르지 않은 정보 입력시 로그인할 수 없습니다")
-		void loginTestWithFail() throws Exception {
-			// given
-			final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, "wrongPassword", UserType.BUYER);
-			final LoginRequest loginRequest = createRequest.toServiceRequest();
-			when(loginService.login(loginRequest)).thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."));
+	@Test
+	@DisplayName("로그인 성공: 회원가입된 판매자는 올바른 정보 입력시 로그인할 수 있습니다")
+	void loginSellerTest() throws Exception {
+		// given
+		final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, validPassword, UserType.SELLER);
+		final LoginRequest loginRequest = createRequest.toServiceRequest();
+		final LoginResponse response = new LoginResponse(validUserId, validName, validEmail);
+		when(loginService.login(loginRequest)).thenReturn(response);
 
-			// when & then
-			mockMvc.perform(MockMvcRequestBuilders.post("/login")
-					.contentType(APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest))
-					.session(session))
-				.andDo(print())
-				.andExpect(status().isUnauthorized());
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest))
+				.session(session))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.id").value(response.id()))
+			.andExpect(jsonPath("$.data.name").value(response.name()))
+			.andExpect(jsonPath("$.data.email").value(response.email()));
 
-			assertThat(session.getAttribute("user")).isNull();
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 이메일로 로그인 시도시 로그인할 수 없습니다")
-		void loginWithNonExistentEmail() throws Exception {
-			// given
-			final LoginCreateRequest createRequest = new LoginCreateRequest("nonexistent@gmail.com", validPassword, UserType.BUYER);
-			final LoginRequest loginRequest = createRequest.toServiceRequest();
-			when(loginService.login(loginRequest)).thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
-
-			// when & then
-			mockMvc.perform(MockMvcRequestBuilders.post("/login")
-					.contentType(APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest))
-					.session(session))
-				.andDo(print())
-				.andExpect(status().isNotFound());
-
-			assertThat(session.getAttribute("user")).isNull();
-		}
+		assertThat(session.getAttribute("user")).isEqualTo(validUserId);
 	}
 
-	@Nested
-	@DisplayName("로그인 엣지 케이스 테스트")
-	class LoginEdgeCases {
-		@Test
-		@DisplayName("이메일이 빈 값일 경우 로그인할 수 없습니다")
-		void loginWithEmptyEmail() throws Exception {
-			// given
-			final LoginCreateRequest createRequest = new LoginCreateRequest("", validPassword, UserType.BUYER);
+	@Test
+	@DisplayName("로그인 실패: 회원가입된 구매자는 올바르지 않은 정보 입력시 로그인할 수 없습니다")
+	void loginTestWithFail() throws Exception {
+		// given
+		final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, "wrongPassword", UserType.BUYER);
+		final LoginRequest loginRequest = createRequest.toServiceRequest();
+		when(loginService.login(loginRequest)).thenThrow(
+			new ResponseStatusException(org.springframework.http.HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."));
 
-			// when & then
-			mockMvc.perform(MockMvcRequestBuilders.post("/login")
-					.contentType(APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest))
-					.session(session))
-				.andDo(print())
-				.andExpect(status().isBadRequest());
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest))
+				.session(session))
+			.andDo(print())
+			.andExpect(status().isUnauthorized());
 
-			verify(loginService, never()).login(any());
-		}
+		assertThat(session.getAttribute("user")).isNull();
+	}
 
-		@Test
-		@DisplayName("비밀번호가 빈 값일 경우 로그인할 수 없습니다")
-		void loginWithEmptyPassword() throws Exception {
-			// given
-			final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, "", UserType.BUYER);
+	@Test
+	@DisplayName("로그인 실패: 존재하지 않는 이메일로 로그인 시도시 로그인할 수 없습니다")
+	void loginWithNonExistentEmail() throws Exception {
+		// given
+		final LoginCreateRequest createRequest = new LoginCreateRequest("nonexistent@gmail.com", validPassword,
+			UserType.BUYER);
+		final LoginRequest loginRequest = createRequest.toServiceRequest();
+		when(loginService.login(loginRequest)).thenThrow(
+			new ResponseStatusException(org.springframework.http.HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
-			// when & then
-			mockMvc.perform(MockMvcRequestBuilders.post("/login")
-					.contentType(APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest))
-					.session(session))
-				.andDo(print())
-				.andExpect(status().isBadRequest());
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest))
+				.session(session))
+			.andDo(print())
+			.andExpect(status().isNotFound());
 
-			verify(loginService, never()).login(any());
-		}
+		assertThat(session.getAttribute("user")).isNull();
+	}
 
-		@Test
-		@DisplayName("잘못된 형식의 이메일로 로그인할 수 없습니다")
-		void loginWithInvalidEmailFormat() throws Exception {
-			// given
-			final LoginCreateRequest createRequest = new LoginCreateRequest("invalid-email", validPassword, UserType.BUYER);
+	@Test
+	@DisplayName("로그인 엣지 케이스: 이메일이 빈 값일 경우 로그인할 수 없습니다")
+	void loginWithEmptyEmail() throws Exception {
+		// given
+		final LoginCreateRequest createRequest = new LoginCreateRequest("", validPassword, UserType.BUYER);
 
-			// when & then
-			mockMvc.perform(MockMvcRequestBuilders.post("/login")
-					.contentType(APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest))
-					.session(session))
-				.andDo(print())
-				.andExpect(status().isBadRequest());
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest))
+				.session(session))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
 
-			verify(loginService, never()).login(any());
-		}
+		verify(loginService, never()).login(any());
+	}
 
-		@Test
-		@DisplayName("사용자 유형이 null일 경우 로그인할 수 없습니다")
-		void loginWithNullUserType() throws Exception {
-			// given
-			final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, validPassword, null);
+	@Test
+	@DisplayName("로그인 엣지 케이스: 비밀번호가 빈 값일 경우 로그인할 수 없습니다")
+	void loginWithEmptyPassword() throws Exception {
+		// given
+		final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, "", UserType.BUYER);
 
-			// when & then
-			mockMvc.perform(MockMvcRequestBuilders.post("/login")
-					.contentType(APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(createRequest))
-					.session(session))
-				.andDo(print())
-				.andExpect(status().isBadRequest());
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest))
+				.session(session))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
 
-			verify(loginService, never()).login(any());
-		}
+		verify(loginService, never()).login(any());
+	}
+
+	@Test
+	@DisplayName("로그인 엣지 케이스: 잘못된 형식의 이메일로 로그인할 수 없습니다")
+	void loginWithInvalidEmailFormat() throws Exception {
+		// given
+		final LoginCreateRequest createRequest = new LoginCreateRequest("invalid-email", validPassword, UserType.BUYER);
+
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest))
+				.session(session))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
+
+		verify(loginService, never()).login(any());
+	}
+
+	@Test
+	@DisplayName("로그인 엣지 케이스: 사용자 유형이 null일 경우 로그인할 수 없습니다")
+	void loginWithNullUserType() throws Exception {
+		// given
+		final LoginCreateRequest createRequest = new LoginCreateRequest(validEmail, validPassword, null);
+
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.post("/login")
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createRequest))
+				.session(session))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
+
+		verify(loginService, never()).login(any());
 	}
 }

--- a/src/test/java/shop/sendbox/sendbox/login/LoginResponseTest.java
+++ b/src/test/java/shop/sendbox/sendbox/login/LoginResponseTest.java
@@ -1,0 +1,61 @@
+package shop.sendbox.sendbox.login;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import shop.sendbox.sendbox.buyer.entity.Buyer;
+import shop.sendbox.sendbox.seller.entity.Seller;
+
+class LoginResponseTest {
+
+	@Test
+	@DisplayName("구매자 정보로 로그인 응답을 생성합니다")
+	void of_WithBuyer_CreatesLoginResponse() {
+		// given
+		Buyer buyer = Buyer.create(
+			"buyer@example.com",
+			"password123",
+			"salt123",
+			"구매자",
+			"01012345678"
+		);
+
+		// Reflection을 사용해 ID를 설정해야 하는데, 이 테스트의 목적상 구현은 생략합니다
+		// 실제 테스트에서는 ReflectionTestUtils 등을 사용하여 설정 가능합니다
+
+		String email = "buyer@example.com";
+
+		// when
+		LoginResponse response = LoginResponse.of(buyer, email);
+
+		// then
+		assertThat(response.name()).isEqualTo("구매자");
+		assertThat(response.email()).isEqualTo(email);
+	}
+
+	@Test
+	@DisplayName("판매자 정보로 로그인 응답을 생성합니다")
+	void of_WithSeller_CreatesLoginResponse() {
+		// given
+		String email = "seller@example.com";
+		Seller seller = Seller.create(
+			"hashedPassword",
+			"salt123",
+			"판매자",
+			"1234567890",
+			"01012345678",
+			email
+		);
+
+		// Reflection을 사용해 ID를 설정해야 하는데, 이 테스트의 목적상 구현은 생략합니다
+
+		// when
+		LoginResponse response = LoginResponse.of(seller, email);
+
+		// then
+		assertThat(response.name()).isEqualTo("판매자");
+		assertThat(response.email()).isEqualTo(email);
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/auth/ApiEndpointEnumTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/auth/ApiEndpointEnumTest.java
@@ -1,0 +1,107 @@
+package shop.sendbox.sendbox.security.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ApiEndpointEnumTest {
+
+	@Test
+	@DisplayName("경로와 메서드가 정확히 일치하면 true를 반환합니다")
+	void matches_whenExactMatch_returnsTrue() {
+		// given
+		String requestUri = "/coupons";
+		String requestMethod = "POST";
+
+		// when
+		boolean result = ApiEndpointEnum.COUPON_CREATE.matches(requestUri, requestMethod);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("쿼리 파라미터가 있어도 경로가 일치하면 true를 반환합니다")
+	void matches_withQueryParams_returnsTrue() {
+		// given
+		String requestUri = "/coupons?name=discount&amount=1000";
+		String requestMethod = "POST";
+
+		// when
+		boolean result = ApiEndpointEnum.COUPON_CREATE.matches(requestUri, requestMethod);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("메서드가 대소문자 구분 없이 일치하면 true를 반환합니다")
+	void matches_withCaseInsensitiveMethod_returnsTrue() {
+		// given
+		String requestUri = "/coupons";
+		String requestMethod = "post";
+
+		// when
+		boolean result = ApiEndpointEnum.COUPON_CREATE.matches(requestUri, requestMethod);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("경로는 같지만 메서드가 다르면 false를 반환합니다")
+	void matches_withDifferentMethod_returnsFalse() {
+		// given
+		String requestUri = "/coupons";
+		String requestMethod = "GET";
+
+		// when
+		boolean result = ApiEndpointEnum.COUPON_CREATE.matches(requestUri, requestMethod);
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("메서드는 같지만 경로가 다르면 false를 반환합니다")
+	void matches_withDifferentPath_returnsFalse() {
+		// given
+		String requestUri = "/orders";
+		String requestMethod = "POST";
+
+		// when
+		boolean result = ApiEndpointEnum.COUPON_CREATE.matches(requestUri, requestMethod);
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("일치하는 엔드포인트가 있으면 해당 권한을 반환합니다")
+	void matchEndpoint_withMatchingEndpoint_returnsCorrectPermission() {
+		// given
+		String requestUri = "/coupons";
+		String requestMethod = "POST";
+
+		// when
+		Permission result = ApiEndpointEnum.matchEndpoint(requestUri, requestMethod);
+
+		// then
+		assertThat(result).isEqualTo(Permission.SELLER);
+	}
+
+	@Test
+	@DisplayName("일치하는 엔드포인트가 없으면 PUBLIC 권한을 반환합니다")
+	void matchEndpoint_withNoMatchingEndpoint_returnsPublicPermission() {
+		// given
+		String requestUri = "/non-existing-path";
+		String requestMethod = "GET";
+
+		// when
+		Permission result = ApiEndpointEnum.matchEndpoint(requestUri, requestMethod);
+
+		// then
+		assertThat(result).isEqualTo(Permission.PUBLIC);
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/auth/PermissionTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/auth/PermissionTest.java
@@ -1,0 +1,80 @@
+package shop.sendbox.sendbox.security.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PermissionTest {
+
+	static Stream<Arguments> providePermissionsAndValues() {
+		return Stream.of(
+			Arguments.of(Permission.PUBLIC, "public"),
+			Arguments.of(Permission.BUYER, "buyer"),
+			Arguments.of(Permission.SELLER, "seller"),
+			Arguments.of(Permission.ADMIN, "admin")
+		);
+	}
+
+	@DisplayName("권한의 값을 조회하면 설정된 값이 반환됩니다")
+	@ParameterizedTest
+	@MethodSource("providePermissionsAndValues")
+	void getValue_ShouldReturnCorrectValue(Permission permission, String expectedValue) {
+		// when
+		String actualValue = permission.getValue();
+
+		// then
+		assertThat(actualValue).isEqualTo(expectedValue);
+	}
+
+	@DisplayName("PUBLIC 권한은 인증이 필요하지 않은 상태입니다")
+	@Test
+	void publicPermission_DoesNotRequireAuth() {
+		// given
+		Permission permission = Permission.PUBLIC;
+
+		// when
+		boolean result = permission.doesNotRequireAuth();
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@DisplayName("PUBLIC이 아닌 권한은 인증이 필요한 상태입니다")
+	@ParameterizedTest
+	@EnumSource(value = Permission.class, names = {"BUYER", "SELLER", "ADMIN"})
+	void nonPublicPermissions_RequireAuth(Permission permission) {
+		// when
+		boolean result = permission.doesNotRequireAuth();
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@DisplayName("모든 권한은 올바른 문자열 값을 가지고 있습니다")
+	@Test
+	void allPermissions_HaveCorrectValues() {
+		// given, when, then
+		assertThat(Permission.PUBLIC.getValue()).isEqualTo("public");
+		assertThat(Permission.BUYER.getValue()).isEqualTo("buyer");
+		assertThat(Permission.SELLER.getValue()).isEqualTo("seller");
+		assertThat(Permission.ADMIN.getValue()).isEqualTo("admin");
+	}
+
+	@DisplayName("권한 열거형은 모든 필요한 권한을 포함하고 있습니다")
+	@Test
+	void enumValues_ShouldContainAllPermissions() {
+		// given, when
+		Permission[] permissions = Permission.values();
+
+		// then
+		assertThat(permissions).hasSize(4)
+			.contains(Permission.PUBLIC, Permission.BUYER, Permission.SELLER, Permission.ADMIN);
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/auth/UserPrincipalTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/auth/UserPrincipalTest.java
@@ -1,0 +1,124 @@
+package shop.sendbox.sendbox.security.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import shop.sendbox.sendbox.login.UserType;
+
+class UserPrincipalTest {
+
+	@DisplayName("사용자 타입이 ADMIN인 경우 isAdmin은 true를 반환합니다")
+	@Test
+	void isAdmin_WhenUserTypeIsAdmin_ReturnsTrue() {
+		// given
+		UserPrincipal adminUser = new UserPrincipal("admin123", UserType.ADMIN);
+
+		// when
+		boolean result = adminUser.isAdmin();
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@DisplayName("사용자 타입이 ADMIN이 아닌 경우 isAdmin은 false를 반환합니다")
+	@ParameterizedTest
+	@EnumSource(value = UserType.class, names = {"BUYER", "SELLER"})
+	void isAdmin_WhenUserTypeIsNotAdmin_ReturnsFalse(UserType userType) {
+		// given
+		UserPrincipal nonAdminUser = new UserPrincipal("user123", userType);
+
+		// when
+		boolean result = nonAdminUser.isAdmin();
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@DisplayName("BUYER 사용자는 BUYER 권한을 가지고 있습니다")
+	@Test
+	void hasPermission_WhenBuyerChecksForBuyerPermission_ReturnsTrue() {
+		// given
+		UserPrincipal buyerUser = new UserPrincipal("buyer123", UserType.BUYER);
+
+		// when, then
+		assertThat(buyerUser.hasPermission(Permission.BUYER)).isTrue();
+	}
+
+	@DisplayName("SELLER 사용자는 SELLER 권한을 가지고 있습니다")
+	@Test
+	void hasPermission_WhenSellerChecksForSellerPermission_ReturnsTrue() {
+		// given
+		UserPrincipal sellerUser = new UserPrincipal("seller123", UserType.SELLER);
+
+		// when, then
+		assertThat(sellerUser.hasPermission(Permission.SELLER)).isTrue();
+	}
+
+	@DisplayName("ADMIN 사용자는 모든 권한을 가지고 있습니다")
+	@ParameterizedTest
+	@EnumSource(value = Permission.class)
+	void hasPermission_WhenAdminChecksForAnyPermission_ReturnsTrue(Permission permission) {
+		// given
+		UserPrincipal adminUser = new UserPrincipal("admin123", UserType.ADMIN);
+
+		// when, then
+		assertThat(adminUser.hasPermission(permission)).isTrue();
+	}
+
+	@DisplayName("BUYER 사용자는 BUYER 외 다른 권한을 확인하면 예외가 발생합니다")
+	@ParameterizedTest
+	@EnumSource(value = Permission.class, names = {"SELLER", "ADMIN", "PUBLIC"})
+	void hasPermission_WhenBuyerChecksForNonBuyerPermission_ThrowsException(Permission permission) {
+		// given
+		UserPrincipal buyerUser = new UserPrincipal("buyer123", UserType.BUYER);
+
+		// when, then
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> buyerUser.hasPermission(permission))
+			.withMessage("권한이 없습니다.");
+	}
+
+	@DisplayName("SELLER 사용자는 SELLER 외 다른 권한을 확인하면 예외가 발생합니다")
+	@ParameterizedTest
+	@EnumSource(value = Permission.class, names = {"BUYER", "ADMIN", "PUBLIC"})
+	void hasPermission_WhenSellerChecksForNonSellerPermission_ThrowsException(Permission permission) {
+		// given
+		UserPrincipal sellerUser = new UserPrincipal("seller123", UserType.SELLER);
+
+		// when, then
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> sellerUser.hasPermission(permission))
+			.withMessage("권한이 없습니다.");
+	}
+
+	@DisplayName("권한 확인시 null을 전달하면 예외가 발생합니다")
+	@Test
+	void hasPermission_WithNullPermission_ThrowsException() {
+		// given
+		UserPrincipal user = new UserPrincipal("user123", UserType.BUYER);
+
+		// when, then
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> user.hasPermission(null))
+			.withMessage("currentPermission은 필수입니다.");
+	}
+
+	@DisplayName("사용자 생성시 ID와 유형이 정상적으로 설정됩니다")
+	@Test
+	void constructor_SetsIdAndUserTypeCorrectly() {
+		// given
+		String id = "test123";
+		UserType userType = UserType.BUYER;
+
+		// when
+		UserPrincipal user = new UserPrincipal(id, userType);
+
+		// then
+		assertThat(user.isAdmin()).isFalse();
+		assertThat(user.hasPermission(Permission.BUYER)).isTrue();
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/auth/context/SecurityPrincipalHolderTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/auth/context/SecurityPrincipalHolderTest.java
@@ -1,0 +1,117 @@
+package shop.sendbox.sendbox.security.auth.context;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+
+import shop.sendbox.sendbox.login.UserType;
+import shop.sendbox.sendbox.security.auth.UserPrincipal;
+import shop.sendbox.sendbox.testsupport.annotation.MockTest;
+
+@MockTest
+class SecurityPrincipalHolderTest {
+
+	@InjectMocks
+	private SecurityPrincipalHolder securityPrincipalHolder;
+
+	@AfterEach
+	void tearDown() {
+		securityPrincipalHolder.clear();
+	}
+
+	@Test
+	@DisplayName("컨텍스트에 사용자 정보가 정상적으로 설정됩니다")
+	void setContextStoresPrincipalCorrectly() {
+		// given
+		UserPrincipal userPrincipal = createUserPrincipal();
+
+		// when
+		securityPrincipalHolder.setContext(userPrincipal);
+
+		// then
+		UserPrincipal result = securityPrincipalHolder.getContext();
+		assertThat(result).isEqualTo(userPrincipal);
+	}
+
+	@Test
+	@DisplayName("컨텍스트에 null 값을 설정하면 예외가 발생합니다")
+	void setContextWithNullThrowsException() {
+		// given
+		UserPrincipal nullPrincipal = null;
+
+		// when & then
+		assertThatThrownBy(() -> securityPrincipalHolder.setContext(nullPrincipal)).isInstanceOf(
+			IllegalArgumentException.class).hasMessage("UserPrincipal은 필수입니다.");
+	}
+
+	@Test
+	@DisplayName("설정되지 않은 컨텍스트를 조회하면 예외가 발생합니다")
+	void getContextFromUnsetContextThrowsException() {
+		// given
+		// 컨텍스트가 설정되지 않은 상태
+
+		// when & then
+		assertThatThrownBy(() -> securityPrincipalHolder.getContext()).isInstanceOf(IllegalStateException.class)
+			.hasMessage("UserPrincipal이 설정되지 않았습니다.");
+	}
+
+	@Test
+	@DisplayName("컨텍스트를 초기화하고 사용하면 예외가 발생합니다.")
+	void clearRemovesContext() {
+		// given
+		UserPrincipal userPrincipal = createUserPrincipal();
+		securityPrincipalHolder.setContext(userPrincipal);
+
+		// when
+		securityPrincipalHolder.clear();
+
+		// then
+		assertThatThrownBy(() -> securityPrincipalHolder.getContext()).isInstanceOf(IllegalStateException.class)
+			.hasMessage("UserPrincipal이 설정되지 않았습니다.");
+	}
+
+	@Test
+	@DisplayName("컨텍스트에 여러 번 설정하면 마지막 사용자 정보로 덮어쓰기됩니다")
+	void setContextOverwritesPreviousValue() {
+		// given
+		UserPrincipal firstPrincipal = createUserPrincipal();
+		UserPrincipal secondPrincipal = createUserPrincipal("2");
+
+		// when
+		securityPrincipalHolder.setContext(firstPrincipal);
+		securityPrincipalHolder.setContext(secondPrincipal);
+
+		// then
+		UserPrincipal result = securityPrincipalHolder.getContext();
+		assertThat(result).isEqualTo(secondPrincipal);
+		assertThat(result).isNotEqualTo(firstPrincipal);
+	}
+
+	@Test
+	@DisplayName("초기화 후 재설정 시 컨텍스트가 정상적으로 작동합니다")
+	void setContextAfterClearWorks() {
+		// given
+		UserPrincipal firstPrincipal = createUserPrincipal();
+		securityPrincipalHolder.setContext(firstPrincipal);
+		securityPrincipalHolder.clear();
+
+		UserPrincipal secondPrincipal = createUserPrincipal("2");
+
+		// when
+		securityPrincipalHolder.setContext(secondPrincipal);
+
+		// then
+		assertThat(securityPrincipalHolder.getContext()).isEqualTo(secondPrincipal);
+	}
+
+	private UserPrincipal createUserPrincipal() {
+		return createUserPrincipal("1");
+	}
+
+	private UserPrincipal createUserPrincipal(String id) {
+		return new UserPrincipal(id, UserType.BUYER);
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/auth/exception/AuthenticationExceptionTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/auth/exception/AuthenticationExceptionTest.java
@@ -1,0 +1,32 @@
+package shop.sendbox.sendbox.security.auth.exception;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuthenticationExceptionTest {
+
+	@Test
+	@DisplayName("인증 예외는 지정된 메시지와 함께 생성됩니다")
+	void constructor_WithMessage_CreatesExceptionWithMessage() {
+		// given
+		String errorMessage = "로그인이 필요합니다.";
+
+		// when
+		AuthenticationException exception = new AuthenticationException(errorMessage);
+
+		// then
+		assertThat(exception.getMessage()).isEqualTo(errorMessage);
+	}
+
+	@Test
+	@DisplayName("인증 예외는 RuntimeException을 상속받습니다")
+	void authenticationException_IsInstanceOfRuntimeException() {
+		// given
+		AuthenticationException exception = new AuthenticationException("테스트 메시지");
+
+		// when & then
+		assertThat(exception).isInstanceOf(RuntimeException.class);
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/auth/filter/ExceptionTranslationFilterTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/auth/filter/ExceptionTranslationFilterTest.java
@@ -1,0 +1,172 @@
+package shop.sendbox.sendbox.security.auth.filter;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import shop.sendbox.sendbox.api.ErrorResponse;
+import shop.sendbox.sendbox.security.auth.exception.AuthenticationException;
+import shop.sendbox.sendbox.security.auth.exception.AuthorizationException;
+import shop.sendbox.sendbox.testsupport.annotation.MockTest;
+
+@MockTest
+class ExceptionTranslationFilterTest {
+
+	private ExceptionTranslationFilter filter;
+	private ObjectMapper objectMapper;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Mock
+	private ServletRequest request;
+
+	@Mock
+	private FilterChain filterChain;
+
+	private StringWriter stringWriter;
+	private PrintWriter writer;
+
+	@BeforeEach
+	void setUp() {
+		objectMapper = new ObjectMapper();
+		filter = new ExceptionTranslationFilter(objectMapper);
+
+		stringWriter = new StringWriter();
+		writer = new PrintWriter(stringWriter);
+	}
+
+	@Test
+	@DisplayName("예외가 발생하지 않으면 필터 체인이 정상적으로 실행됩니다")
+	void normalCase() throws IOException, ServletException {
+		// given
+		doNothing().when(filterChain).doFilter(request, response);
+
+		// when
+		filter.doFilter(request, response, filterChain);
+
+		// then
+		verify(filterChain, times(1)).doFilter(request, response);
+		verify(response, never()).setStatus(anyInt());
+		verify(response, never()).setContentType(anyString());
+	}
+
+	@Test
+	@DisplayName("인증 예외가 발생하면 401 응답을 반환합니다")
+	void authenticationExceptionCase() throws IOException, ServletException {
+		// given
+		doThrow(new AuthenticationException("인증 실패"))
+			.when(filterChain)
+			.doFilter(request, response);
+		when(response.isCommitted()).thenReturn(false);
+		when(response.getWriter()).thenReturn(writer);
+
+		// when
+		filter.doFilter(request, response, filterChain);
+		writer.flush();
+
+		// then
+		verify(response).setStatus(401);
+		verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+		verify(response).setCharacterEncoding("UTF-8");
+
+		String actualResponse = stringWriter.toString();
+		ErrorResponse errorResponse = objectMapper.readValue(actualResponse, ErrorResponse.class);
+
+		assertThat(errorResponse.statusCode()).isEqualTo(401);
+		assertThat(errorResponse.message()).isEqualTo("UNAUTHORIZED");
+		assertThat(errorResponse.errorCode()).isEqualTo("AUTH_001");
+		assertThat(errorResponse.errorDetail()).isEqualTo("이 리소스에 접근하기 위해서는 인증이 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("인가 예외가 발생하면 403 응답을 반환합니다")
+	void authorizationExceptionCase() throws IOException, ServletException {
+		// given
+		doThrow(new AuthorizationException("권한 없음"))
+			.when(filterChain)
+			.doFilter(request, response);
+		when(response.isCommitted()).thenReturn(false);
+		when(response.getWriter()).thenReturn(writer);
+
+		// when
+		filter.doFilter(request, response, filterChain);
+		writer.flush();
+
+		// then
+		verify(response).setStatus(403);
+		verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+		verify(response).setCharacterEncoding("UTF-8");
+
+		String actualResponse = stringWriter.toString();
+		ErrorResponse errorResponse = objectMapper.readValue(actualResponse, ErrorResponse.class);
+
+		assertThat(errorResponse.statusCode()).isEqualTo(403);
+		assertThat(errorResponse.message()).isEqualTo("ACCESS_DENIED");
+		assertThat(errorResponse.errorCode()).isEqualTo("AUTH_003");
+		assertThat(errorResponse.errorDetail()).isEqualTo("이 리소스에 접근할 권한이 없습니다.");
+	}
+
+	@Test
+	@DisplayName("예기치 않은 예외가 발생하면 500 응답을 반환합니다")
+	void unexpectedExceptionCase() throws IOException, ServletException {
+		// given
+		doThrow(new RuntimeException("예기치 않은 오류"))
+			.when(filterChain)
+			.doFilter(request, response);
+		when(response.isCommitted()).thenReturn(false);
+		when(response.getWriter()).thenReturn(writer);
+
+		// when
+		filter.doFilter(request, response, filterChain);
+		writer.flush();
+
+		// then
+		verify(response).setStatus(500);
+		verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+		verify(response).setCharacterEncoding("UTF-8");
+
+		String actualResponse = stringWriter.toString();
+		ErrorResponse errorResponse = objectMapper.readValue(actualResponse, ErrorResponse.class);
+
+		assertThat(errorResponse.statusCode()).isEqualTo(500);
+		assertThat(errorResponse.message()).isEqualTo("SERVER_ERROR");
+		assertThat(errorResponse.errorCode()).isEqualTo("SYS_001");
+		assertThat(errorResponse.errorDetail()).isEqualTo("예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요.");
+	}
+
+	@Test
+	@DisplayName("응답이 이미 커밋된 경우 에러 응답을 추가하지 않습니다")
+	void responseAlreadyCommittedCase() throws IOException, ServletException {
+		// given
+		doThrow(new AuthenticationException("인증 실패"))
+			.when(filterChain)
+			.doFilter(request, response);
+		when(response.isCommitted()).thenReturn(true);
+
+		// when
+		filter.doFilter(request, response, filterChain);
+
+		// then
+		verify(response, never()).setStatus(anyInt());
+		verify(response, never()).setContentType(anyString());
+		verify(response, never()).setCharacterEncoding(anyString());
+		verify(response, never()).getWriter();
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/auth/filter/SessionAuthenticationFilterTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/auth/filter/SessionAuthenticationFilterTest.java
@@ -1,0 +1,210 @@
+package shop.sendbox.sendbox.security.auth.filter;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import shop.sendbox.sendbox.login.UserType;
+import shop.sendbox.sendbox.security.auth.ApiEndpointEnum;
+import shop.sendbox.sendbox.security.auth.Permission;
+import shop.sendbox.sendbox.security.auth.UserPrincipal;
+import shop.sendbox.sendbox.security.auth.context.SecurityPrincipalHolder;
+import shop.sendbox.sendbox.security.auth.exception.AuthenticationException;
+import shop.sendbox.sendbox.testsupport.annotation.MockTest;
+
+@MockTest
+class SessionAuthenticationFilterTest {
+
+	@Mock
+	private SecurityPrincipalHolder securityPrincipalHolder;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Mock
+	private FilterChain filterChain;
+
+	@Mock
+	private HttpSession session;
+
+	@Mock
+	private UserPrincipal userPrincipal;
+
+	private SessionAuthenticationFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		filter = new SessionAuthenticationFilter(securityPrincipalHolder);
+	}
+
+	@Test
+	@DisplayName("인증이 필요한 API 요청 시 세션에서 유저 정보를 가져와 컨텍스트에 설정합니다")
+	void doFilter_AuthenticatedEndpoint_SetsUserPrincipalAndPassesFilter() throws ServletException, IOException {
+		// given - 인증이 필요한 엔드포인트로 설정 (COUPON_CREATE는 SELLER 권한 필요)
+		given(request.getRequestURI()).willReturn("/coupons");
+		given(request.getMethod()).willReturn("POST");
+		UserPrincipal userPrincipal = new UserPrincipal("testUser", UserType.SELLER);
+		given(session.getAttribute("userPrincipal")).willReturn(userPrincipal);
+		given(request.getSession(false)).willReturn(session);
+
+		// when
+		filter.doFilter(request, response, filterChain);
+
+		// then
+		verify(securityPrincipalHolder).setContext(userPrincipal);
+		verify(filterChain).doFilter(request, response);
+		verify(securityPrincipalHolder).clear();
+	}
+
+	@Test
+	@DisplayName("인증이 필요하지 않은 API 요청 시 컨텍스트 설정 없이 다음 필터로 진행합니다")
+	void doFilter_NonAuthenticatedEndpoint_SkipsAuthentication() throws ServletException, IOException {
+		// given - 기존에 없는 엔드포인트는 PUBLIC으로 처리됨
+		given(request.getRequestURI()).willReturn("/api/products");
+		given(request.getMethod()).willReturn("GET");
+
+		// when
+		filter.doFilter(request, response, filterChain);
+
+		// then
+		verify(securityPrincipalHolder, never()).setContext(any());
+		verify(filterChain).doFilter(request, response);
+	}
+
+	@Test
+	@DisplayName("세션이 존재하지 않을 때 인증 예외가 발생합니다")
+	void doFilter_NoSession_ThrowsAuthenticationException() {
+		// given
+		given(request.getRequestURI()).willReturn("/coupons");
+		given(request.getMethod()).willReturn("POST");
+		given(request.getSession(false)).willReturn(null);
+
+		// when & then
+		assertThatThrownBy(() -> filter.doFilter(request, response, filterChain))
+			.isInstanceOf(AuthenticationException.class)
+			.hasMessage("로그인이 필요합니다.");
+
+		verify(securityPrincipalHolder).clear();
+	}
+
+	@Test
+	@DisplayName("세션에 유효한 유저 정보가 없을 때 인증 예외가 발생합니다")
+	void doFilter_InvalidUserPrincipal_ThrowsAuthenticationException() {
+		// given
+		given(request.getRequestURI()).willReturn("/coupons");
+		given(request.getMethod()).willReturn("POST");
+		Object userPrincipal = new Object();
+		given(session.getAttribute("userPrincipal")).willReturn(userPrincipal);
+		given(request.getSession(false)).willReturn(session);
+
+		// when & then
+		assertThatThrownBy(() -> filter.doFilter(request, response, filterChain))
+			.isInstanceOf(AuthenticationException.class)
+			.hasMessage("유효한 사용자 정보가 아닙니다.");
+
+		verify(securityPrincipalHolder).clear();
+	}
+
+	@Test
+	@DisplayName("필터 처리 중 예외가 발생해도 컨텍스트는 정상적으로 초기화됩니다")
+	void doFilter_ExceptionInChain_ClearsContextAnyway() throws ServletException, IOException {
+		// given
+		given(request.getRequestURI()).willReturn("/coupons");
+		given(request.getMethod()).willReturn("POST");
+		Object userPrincipal = new UserPrincipal("testUser", UserType.SELLER);
+		given(session.getAttribute("userPrincipal")).willReturn(userPrincipal);
+		given(request.getSession(false)).willReturn(session);
+		RuntimeException expectedException = new RuntimeException("필터 체인 처리 중 오류 발생");
+		doThrow(expectedException).when(filterChain).doFilter(request, response);
+
+		// when & then
+		assertThatThrownBy(() -> filter.doFilter(request, response, filterChain))
+			.isInstanceOf(RuntimeException.class);
+
+		verify(securityPrincipalHolder).clear();
+	}
+
+	@DisplayName("권한에 따라 인증 필요 여부가 올바르게 결정됩니다")
+	@ParameterizedTest
+	@MethodSource("providePermissionsAndAuthRequirements")
+	void permission_DoesNotRequireAuth_ReturnsCorrectValue(Permission permission, boolean expectedAuthRequired) {
+		// when & then
+		assertThat(permission.doesNotRequireAuth()).isEqualTo(expectedAuthRequired);
+	}
+
+	static Stream<Arguments> providePermissionsAndAuthRequirements() {
+		return Stream.of(
+			Arguments.of(Permission.PUBLIC, true),
+			Arguments.of(Permission.BUYER, false),
+			Arguments.of(Permission.SELLER, false),
+			Arguments.of(Permission.ADMIN, false)
+		);
+	}
+
+	@DisplayName("Permission 열거형은 지정된 값을 올바르게 반환합니다")
+	@ParameterizedTest
+	@MethodSource("providePermissionsAndValues")
+	void permission_GetValue_ReturnsCorrectValue(Permission permission, String expectedValue) {
+		// when & then
+		assertThat(permission.getValue()).isEqualTo(expectedValue);
+	}
+
+	static Stream<Arguments> providePermissionsAndValues() {
+		return Stream.of(
+			Arguments.of(Permission.PUBLIC, "public"),
+			Arguments.of(Permission.BUYER, "buyer"),
+			Arguments.of(Permission.SELLER, "seller"),
+			Arguments.of(Permission.ADMIN, "admin")
+		);
+	}
+
+	@Test
+	@DisplayName("ApiEndpointEnum은 경로와 메서드에 따라 올바른 권한을 매칭합니다")
+	void apiEndpointEnum_MatchesCorrectPermission() {
+		// given & when & then
+		assertThat(ApiEndpointEnum.matchEndpoint("/coupons", "POST")).isEqualTo(Permission.SELLER);
+
+		// 매칭되는 엔드포인트가 없으면 PUBLIC 반환
+		assertThat(ApiEndpointEnum.matchEndpoint("/unknown", "GET")).isEqualTo(Permission.PUBLIC);
+	}
+
+	@Test
+	@DisplayName("ApiEndpointEnum은 경로 매칭 시 쿼리 파라미터를 제거합니다")
+	void apiEndpointEnum_RemovesQueryString() {
+		// given
+		ApiEndpointEnum endpoint = ApiEndpointEnum.COUPON_CREATE;
+
+		// when & then
+		assertThat(endpoint.matches("/coupons?name=test", "POST")).isTrue();
+		assertThat(endpoint.matches("/coupons", "POST")).isTrue();
+	}
+
+	@Test
+	@DisplayName("ApiEndpointEnum은 HTTP 메서드가 일치하지 않으면 매칭되지 않습니다")
+	void apiEndpointEnum_DoesNotMatchForDifferentMethod() {
+		// given
+		ApiEndpointEnum endpoint = ApiEndpointEnum.COUPON_CREATE;
+
+		// when & then
+		assertThat(endpoint.matches("/coupons", "GET")).isFalse();
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/auth/interceptor/AuthorizationInterceptorTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/auth/interceptor/AuthorizationInterceptorTest.java
@@ -1,0 +1,129 @@
+package shop.sendbox.sendbox.security.auth.interceptor;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import shop.sendbox.sendbox.security.auth.ApiEndpointEnum;
+import shop.sendbox.sendbox.security.auth.Permission;
+import shop.sendbox.sendbox.security.auth.UserPrincipal;
+import shop.sendbox.sendbox.security.auth.context.SecurityPrincipalHolder;
+import shop.sendbox.sendbox.security.auth.exception.AuthorizationException;
+import shop.sendbox.sendbox.testsupport.annotation.MockTest;
+
+@MockTest
+class AuthorizationInterceptorTest {
+
+	@Mock
+	private SecurityPrincipalHolder securityPrincipalHolder;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Mock
+	private Object handler;
+
+	@Mock
+	private UserPrincipal userPrincipal;
+
+	@Mock
+	private Permission permission;
+
+	@InjectMocks
+	private AuthorizationInterceptor interceptor;
+
+	@BeforeEach
+	void setUp() {
+		when(request.getRequestURI()).thenReturn("/api/v1/test");
+		when(request.getMethod()).thenReturn("GET");
+	}
+
+	@Test
+	@DisplayName("인증이 필요 없는 엔드포인트는 항상 접근이 허용됩니다")
+	void permitAllEndpointTest() throws Exception {
+		// given
+		try (MockedStatic<ApiEndpointEnum> apiEndpointEnumMockedStatic = mockStatic(ApiEndpointEnum.class)) {
+			apiEndpointEnumMockedStatic.when(() -> ApiEndpointEnum.matchEndpoint(anyString(), anyString()))
+				.thenReturn(permission);
+			when(permission.doesNotRequireAuth()).thenReturn(true);
+
+			// when
+			boolean result = interceptor.preHandle(request, response, handler);
+
+			// then
+			assertThat(result).isTrue();
+			verify(securityPrincipalHolder, never()).getContext();
+			verify(userPrincipal, never()).hasPermission(any());
+		}
+	}
+
+	@Test
+	@DisplayName("사용자가 필요한 권한을 가지고 있으면 접근이 허용됩니다")
+	void userHasPermissionTest() throws Exception {
+		// given
+		try (MockedStatic<ApiEndpointEnum> apiEndpointEnumMockedStatic = mockStatic(ApiEndpointEnum.class)) {
+			apiEndpointEnumMockedStatic.when(() -> ApiEndpointEnum.matchEndpoint(anyString(), anyString()))
+				.thenReturn(permission);
+			when(permission.doesNotRequireAuth()).thenReturn(false);
+			when(securityPrincipalHolder.getContext()).thenReturn(userPrincipal);
+			when(userPrincipal.hasPermission(permission)).thenReturn(true);
+
+			// when
+			boolean result = interceptor.preHandle(request, response, handler);
+
+			// then
+			assertThat(result).isTrue();
+			verify(securityPrincipalHolder).getContext();
+			verify(userPrincipal).hasPermission(permission);
+		}
+	}
+
+	@Test
+	@DisplayName("사용자가 필요한 권한을 가지고 있지 않으면 접근이 거부됩니다")
+	void userDoesNotHavePermissionTest() throws Exception {
+		// given
+		try (MockedStatic<ApiEndpointEnum> apiEndpointEnumMockedStatic = mockStatic(ApiEndpointEnum.class)) {
+			apiEndpointEnumMockedStatic.when(() -> ApiEndpointEnum.matchEndpoint(anyString(), anyString()))
+				.thenReturn(permission);
+			when(permission.doesNotRequireAuth()).thenReturn(false);
+			when(securityPrincipalHolder.getContext()).thenReturn(userPrincipal);
+			when(userPrincipal.hasPermission(permission)).thenReturn(false);
+
+			// when
+			boolean result = interceptor.preHandle(request, response, handler);
+
+			// then
+			assertThat(result).isFalse();
+			verify(securityPrincipalHolder).getContext();
+			verify(userPrincipal).hasPermission(permission);
+		}
+	}
+
+	@Test
+	@DisplayName("SecurityPrincipalHolder에 값이 없는 경우 요청이 거부됩니다.")
+	void nullUserPrincipalTest() throws Exception {
+		// given
+		try (MockedStatic<ApiEndpointEnum> apiEndpointEnumMockedStatic = mockStatic(ApiEndpointEnum.class)) {
+			apiEndpointEnumMockedStatic.when(() -> ApiEndpointEnum.matchEndpoint(anyString(), anyString()))
+				.thenReturn(permission);
+			when(permission.doesNotRequireAuth()).thenReturn(false);
+			when(securityPrincipalHolder.getContext()).thenReturn(null);
+
+			// when
+			assertThatThrownBy(() -> interceptor.preHandle(request, response, handler))
+				.isInstanceOf(AuthorizationException.class)
+				.hasMessage("로그인이 필요합니다.");
+		}
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/security/crypto/symmetric/AesEncryptServiceTest.java
+++ b/src/test/java/shop/sendbox/sendbox/security/crypto/symmetric/AesEncryptServiceTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import shop.sendbox.sendbox.security.config.SecurityConfig;
+import shop.sendbox.sendbox.security.crypto.config.SecurityConfig;
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/shop/sendbox/sendbox/seller/controller/SellerControllerTest.java
+++ b/src/test/java/shop/sendbox/sendbox/seller/controller/SellerControllerTest.java
@@ -19,14 +19,14 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import shop.sendbox.sendbox.api.ApiControllerAdvice;
 import shop.sendbox.sendbox.seller.service.SellerCreateCommand;
 import shop.sendbox.sendbox.seller.service.SellerCreateResult;
 import shop.sendbox.sendbox.seller.service.SellerService;
+import shop.sendbox.sendbox.testsupport.config.TestHolderConfig;
+import shop.sendbox.sendbox.testsupport.config.TestNoWebMvcConfig;
 
-@WebMvcTest(SellerController.class)
-@Import(ApiControllerAdvice.class)
-@DisplayName("판매자 컨트롤러 테스트")
+@WebMvcTest(controllers = SellerController.class)
+@Import({TestHolderConfig.class, TestNoWebMvcConfig.class})
 class SellerControllerTest {
 
 	@Autowired

--- a/src/test/java/shop/sendbox/sendbox/seller/service/SellerServiceTest.java
+++ b/src/test/java/shop/sendbox/sendbox/seller/service/SellerServiceTest.java
@@ -1,73 +1,219 @@
 package shop.sendbox.sendbox.seller.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
-import shop.sendbox.sendbox.buyer.entity.YnCode;
-import shop.sendbox.sendbox.security.service.SecurityService;
+import shop.sendbox.sendbox.login.LoginResponse;
+import shop.sendbox.sendbox.login.LoginUser;
+import shop.sendbox.sendbox.login.UserType;
+import shop.sendbox.sendbox.security.crypto.dto.PasswordData;
+import shop.sendbox.sendbox.security.crypto.service.SecurityService;
 import shop.sendbox.sendbox.seller.entity.Seller;
-import shop.sendbox.sendbox.seller.entity.SellerStatus;
 import shop.sendbox.sendbox.seller.repository.SellerRepository;
+import shop.sendbox.sendbox.testsupport.annotation.MockTest;
 
-@SpringBootTest
-@Transactional
+@MockTest
 class SellerServiceTest {
 
-	@Autowired
+	@Mock
 	private SellerRepository sellerRepository;
 
-	@Autowired
+	@Mock
 	private SecurityService securityService;
 
-	@Autowired
+	@InjectMocks
 	private SellerService sellerService;
 
 	@Test
-	@DisplayName("판매자 회원가입: 정상적인 정보 입력 시 성공적으로 가입 처리됩니다.")
-	void createSellerSuccess() {
+	@DisplayName("판매자 등록이 성공하면 판매자 정보가 저장됩니다")
+	void createSeller_WithValidData_SavesSeller() {
 		// given
-		SellerCreateCommand request = new SellerCreateCommand("홍길동상회", "password123",
-			"123-45-67890", "010-1234-5678", "tax@example.com");
+		SellerCreateCommand command = new SellerCreateCommand(
+			"password", "판매자", "1234567890", "010-1234-5678", "seller@example.com"
+		);
+
+		String encryptedPhoneNumber = "encryptedPhoneNumber";
+		String encryptedTaxEmail = "encryptedTaxEmail";
+		String encryptedBusinessNumber = "encryptedBusinessNumber";
+		PasswordData passwordData = new PasswordData("hashedPassword", "salt");
+
+		when(securityService.encryptText(command.phoneNumber())).thenReturn(encryptedPhoneNumber);
+		when(securityService.encryptText(command.taxEmail())).thenReturn(encryptedTaxEmail);
+		when(securityService.encryptText(command.businessNumber())).thenReturn(encryptedBusinessNumber);
+		when(securityService.encryptPassword(command.password())).thenReturn(passwordData);
+
+		when(sellerRepository.existsByBusinessNumber(encryptedBusinessNumber)).thenReturn(false);
+		when(sellerRepository.existsByTaxEmail(encryptedTaxEmail)).thenReturn(false);
+
+		Seller savedSeller = Seller.create(
+			passwordData.hashedPassword(),
+			passwordData.salt(),
+			command.name(),
+			encryptedBusinessNumber,
+			encryptedPhoneNumber,
+			encryptedTaxEmail
+		);
+		// Reflection 등을 사용하여 ID를 설정해야 하지만, 테스트 목적상 mockito로 대체
+		when(sellerRepository.save(any(Seller.class))).thenReturn(savedSeller);
+
+		when(securityService.decryptText(encryptedPhoneNumber)).thenReturn(command.phoneNumber());
+		when(securityService.decryptText(encryptedTaxEmail)).thenReturn(command.taxEmail());
 
 		// when
-		SellerCreateResult response = sellerService.createSeller(request);
+		SellerCreateResult result = sellerService.createSeller(command);
 
 		// then
-		assertThat(response.id()).isNotNull();
-		assertThat(response.name()).isEqualTo(request.name());
-		assertThat(response.phoneNumber()).isEqualTo(request.phoneNumber());
-		assertThat(response.taxEmail()).isEqualTo(request.taxEmail());
+		assertThat(result).isNotNull();
+		assertThat(result.name()).isEqualTo(command.name());
+		assertThat(result.phoneNumber()).isEqualTo(command.phoneNumber());
+		assertThat(result.taxEmail()).isEqualTo(command.taxEmail());
 
-		Seller savedSeller = sellerRepository.findById(response.id()).orElseThrow();
-		assertThat(savedSeller.getName()).isEqualTo(request.name());
-		assertThat(securityService.decryptText(savedSeller.getBusinessNumber())).isEqualTo(request.businessNumber());
-		assertThat(securityService.decryptText(savedSeller.getPhoneNumber())).isEqualTo(request.phoneNumber());
-		assertThat(securityService.decryptText(savedSeller.getTaxEmail())).isEqualTo(request.taxEmail());
-		assertThat(savedSeller.getSellerStatus()).isEqualTo(SellerStatus.ACTIVE);
-		assertThat(savedSeller.getDeleteYn()).isEqualTo(YnCode.N);
-		assertThat(securityService.verifyPassword(request.password(), savedSeller.getPassword(),
-			savedSeller.getSalt())).isTrue();
+		verify(sellerRepository).save(any(Seller.class));
 	}
 
 	@Test
-	@DisplayName("판매자 회원가입 실패: 이미 등록된 사업자 번호로 가입 시도 시 예외가 발생합니다.")
-	void createSellerFailDueToDuplicateBusinessNumber() {
+	@DisplayName("이미 등록된 사업자번호로 판매자 등록 시 예외가 발생합니다")
+	void createSeller_WithDuplicateBusinessNumber_ThrowsException() {
 		// given
-		SellerCreateCommand initialRequest = new SellerCreateCommand("기존상회", "password123",
-				"987-65-43210", "010-9999-8888", "initial@example.com");
-		sellerService.createSeller(initialRequest);
+		SellerCreateCommand command = new SellerCreateCommand(
+			"password", "판매자", "1234567890", "010-1234-5678", "seller@example.com"
+		);
 
-		SellerCreateCommand duplicateRequest = new SellerCreateCommand("새로운상회", "newpass",
-			"987-65-43210", "010-1111-2222", "new@example.com");
+		String encryptedBusinessNumber = "encryptedBusinessNumber";
+		when(securityService.encryptText(command.businessNumber())).thenReturn(encryptedBusinessNumber);
+		when(sellerRepository.existsByBusinessNumber(encryptedBusinessNumber)).thenReturn(true);
 
 		// when & then
-		assertThatThrownBy(() -> sellerService.createSeller(duplicateRequest)).isInstanceOf(
-			IllegalArgumentException.class).hasMessage("이미 등록된 사업자번호입니다.");
+		assertThatThrownBy(() -> sellerService.createSeller(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("이미 등록된 사업자번호입니다.");
+	}
+
+	@Test
+	@DisplayName("이미 등록된 세금계산서 이메일로 판매자 등록 시 예외가 발생합니다")
+	void createSeller_WithDuplicateTaxEmail_ThrowsException() {
+		// given
+		SellerCreateCommand command = new SellerCreateCommand(
+			"password", "판매자", "1234567890", "010-1234-5678", "seller@example.com"
+		);
+
+		String encryptedBusinessNumber = "encryptedBusinessNumber";
+		String encryptedTaxEmail = "encryptedTaxEmail";
+
+		when(securityService.encryptText(command.businessNumber())).thenReturn(encryptedBusinessNumber);
+		when(sellerRepository.existsByBusinessNumber(encryptedBusinessNumber)).thenReturn(false);
+
+		when(securityService.encryptText(command.taxEmail())).thenReturn(encryptedTaxEmail);
+		when(sellerRepository.existsByTaxEmail(encryptedTaxEmail)).thenReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> sellerService.createSeller(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("이미 등록된 세금 계산서용 이메일입니다.");
+	}
+
+	@Test
+	@DisplayName("유효한 이메일과 비밀번호로 로그인 시 로그인이 성공합니다")
+	void login_WithValidCredentials_ReturnsLoginResponse() {
+		// given
+		LoginUser loginUser = new LoginUser("seller@example.com", "password");
+		String encryptedEmail = "encryptedEmail";
+
+		when(securityService.encryptText(loginUser.email())).thenReturn(encryptedEmail);
+
+		Seller seller = Seller.create(
+			"hashedPassword",
+			"salt",
+			"판매자",
+			"encryptedBusinessNumber",
+			"encryptedPhoneNumber",
+			encryptedEmail
+		);
+
+		when(sellerRepository.findByTaxEmail(encryptedEmail)).thenReturn(Optional.of(seller));
+		when(securityService.verifyPassword(loginUser.password(), seller.getPassword(), seller.getSalt())).thenReturn(
+			true);
+
+		// when
+		LoginResponse response = sellerService.login(loginUser);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.name()).isEqualTo(seller.getName());
+		assertThat(response.email()).isEqualTo(loginUser.email());
+	}
+
+	@Test
+	@DisplayName("등록되지 않은 이메일로 로그인 시 예외가 발생합니다")
+	void login_WithNonExistingEmail_ThrowsException() {
+		// given
+		LoginUser loginUser = new LoginUser("nonexisting@example.com", "password");
+		String encryptedEmail = "encryptedEmail";
+
+		when(securityService.encryptText(loginUser.email())).thenReturn(encryptedEmail);
+		when(sellerRepository.findByTaxEmail(encryptedEmail)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> sellerService.login(loginUser))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("해당 이메일로 가입된 판매자가 없습니다.");
+	}
+
+	@Test
+	@DisplayName("잘못된 비밀번호로 로그인 시 예외가 발생합니다")
+	void login_WithInvalidPassword_ThrowsException() {
+		// given
+		LoginUser loginUser = new LoginUser("seller@example.com", "wrongPassword");
+		String encryptedEmail = "encryptedEmail";
+
+		when(securityService.encryptText(loginUser.email())).thenReturn(encryptedEmail);
+
+		// Create a Seller using the provided builder pattern
+		Seller seller = Seller.create(
+			"hashedPassword",
+			"salt",
+			"판매자",
+			"encryptedBusinessNumber",
+			"encryptedPhoneNumber",
+			encryptedEmail
+		);
+
+		when(sellerRepository.findByTaxEmail(encryptedEmail)).thenReturn(Optional.of(seller));
+		when(securityService.verifyPassword(loginUser.password(), seller.getPassword(), seller.getSalt())).thenReturn(
+			false);
+
+		// when & then
+		assertThatThrownBy(() -> sellerService.login(loginUser))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("비밀번호가 일치하지 않습니다.");
+	}
+
+	@Test
+	@DisplayName("판매자 유형 확인 시 SELLER 유형은 지원합니다")
+	void supports_WithSellerType_ReturnsTrue() {
+		// when
+		boolean result = sellerService.supports(UserType.SELLER);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("판매자 유형 확인 시 SELLER가 아닌 유형은 지원하지 않습니다")
+	void supports_WithNonSellerType_ReturnsFalse() {
+		// when
+		boolean result = sellerService.supports(UserType.BUYER);
+
+		// then
+		assertThat(result).isFalse();
 	}
 }
 

--- a/src/test/java/shop/sendbox/sendbox/testsupport/annotation/MockTest.java
+++ b/src/test/java/shop/sendbox/sendbox/testsupport/annotation/MockTest.java
@@ -1,0 +1,15 @@
+package shop.sendbox.sendbox.testsupport.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(MockitoExtension.class)
+public @interface MockTest {
+}

--- a/src/test/java/shop/sendbox/sendbox/testsupport/config/TestHolderConfig.java
+++ b/src/test/java/shop/sendbox/sendbox/testsupport/config/TestHolderConfig.java
@@ -1,0 +1,15 @@
+package shop.sendbox.sendbox.testsupport.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import shop.sendbox.sendbox.security.auth.context.SecurityPrincipalHolder;
+
+@TestConfiguration
+public class TestHolderConfig {
+
+	@Bean
+	public SecurityPrincipalHolder testSecurityPrincipalHolder() {
+		return new SecurityPrincipalHolder();
+	}
+}

--- a/src/test/java/shop/sendbox/sendbox/testsupport/config/TestNoWebMvcConfig.java
+++ b/src/test/java/shop/sendbox/sendbox/testsupport/config/TestNoWebMvcConfig.java
@@ -1,0 +1,22 @@
+package shop.sendbox.sendbox.testsupport.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@TestConfiguration
+public class TestNoWebMvcConfig {
+
+	@Bean
+	@Primary
+	public WebMvcConfigurer webMvcConfigurerOverride() {
+		return new WebMvcConfigurer() {
+			@Override
+			public void addInterceptors(InterceptorRegistry registry) {
+				// 아무것도 등록하지 않음
+			}
+		};
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #32 인증 / 인가 구현

## 📝작업 내용
> 인증/인가에 대한 구현을 해보았습니다.

## :black_nib: 코드 변경 이유
- 인증/인가를 구현할 때 확장에 자유롭도록 인증은 필터/ 인가는 인터셉터에서 구현하려고 했습니다.
- 인증 인가를 모두 필터에서 구현할 수 있지만 서블릿 레벨에서 url과 요청마다 다른 인가를 필터에서 처리하는 것보다 
인터셉터에서 처리하는 것이 더 유연하게 처리할 수 있기 때문입니다.

## 객체지향 체조 3가지 확인📌
  
- [x] 한 줄에 점을 하나만 찍는다.
- [x] else 키워드를 쓰지 않는다.
- [x] 일급 컬렉션을 사용한다.
